### PR TITLE
Improve caffe2npz in example/ssd

### DIFF
--- a/examples/ssd/caffe2npz.py
+++ b/examples/ssd/caffe2npz.py
@@ -9,29 +9,29 @@ from chainercv.links.model.ssd import Normalize
 
 
 def rename(name):
-    m = re.fullmatch(r'conv(\d+)_([123])', name)
+    m = re.match(r'conv(\d+)_([123])$', name)
     if m:
         i, j = map(int, m.groups())
         if i >= 6:
             i += 2
         return 'extractor/conv{:d}_{:d}'.format(i, j)
 
-    m = re.fullmatch(r'fc([67])', name)
+    m = re.match(r'fc([67])$', name)
     if m:
         return 'extractor/conv{:d}'.format(int(m.group(1)))
 
     if name == r'conv4_3_norm':
         return 'extractor/norm4'
 
-    m = re.fullmatch(r'conv4_3_norm_mbox_(loc|conf)', name)
+    m = re.match(r'conv4_3_norm_mbox_(loc|conf)$', name)
     if m:
         return 'multibox/{:s}/0'.format(m.group(1))
 
-    m = re.fullmatch(r'fc7_mbox_(loc|conf)', name)
+    m = re.match(r'fc7_mbox_(loc|conf)$', name)
     if m:
         return ('multibox/{:s}/1'.format(m.group(1)))
 
-    m = re.fullmatch(r'conv(\d+)_2_mbox_(loc|conf)', name)
+    m = re.match(r'conv(\d+)_2_mbox_(loc|conf)$', name)
     if m:
         i, type_ = int(m.group(1)), m.group(2)
         if i >= 6:

--- a/examples/ssd/caffe2npz.py
+++ b/examples/ssd/caffe2npz.py
@@ -9,29 +9,29 @@ from chainercv.links.model.ssd import Normalize
 
 
 def rename(name):
-    m = re.match(r'^conv(\d+)_([123])$', name)
+    m = re.fullmatch(r'conv(\d+)_([123])', name)
     if m:
         i, j = map(int, m.groups())
         if i >= 6:
             i += 2
         return 'extractor/conv{:d}_{:d}'.format(i, j)
 
-    m = re.match(r'^fc([67])$', name)
+    m = re.fullmatch(r'fc([67])', name)
     if m:
         return 'extractor/conv{:d}'.format(int(m.group(1)))
 
     if name == r'conv4_3_norm':
         return 'extractor/norm4'
 
-    m = re.match(r'^conv4_3_norm_mbox_(loc|conf)$', name)
+    m = re.fullmatch(r'conv4_3_norm_mbox_(loc|conf)', name)
     if m:
         return 'multibox/{:s}/0'.format(m.group(1))
 
-    m = re.match(r'^fc7_mbox_(loc|conf)$', name)
+    m = re.fullmatch(r'fc7_mbox_(loc|conf)', name)
     if m:
         return ('multibox/{:s}/1'.format(m.group(1)))
 
-    m = re.match(r'^conv(\d+)_2_mbox_(loc|conf)$', name)
+    m = re.fullmatch(r'conv(\d+)_2_mbox_(loc|conf)', name)
     if m:
         i, type_ = int(m.group(1)), m.group(2)
         if i >= 6:

--- a/examples/ssd/caffe2npz.py
+++ b/examples/ssd/caffe2npz.py
@@ -89,7 +89,7 @@ def main():
         conv = model[child.name]
         for data in (conv.W.data, conv.b.data):
             data = data.reshape((-1, 4) + data.shape[1:])
-            data[:, [1, 0, 3, 2]] = data
+            data[:, [1, 0, 3, 2]] = data.copy()
 
     serializers.save_npz(args.output, model)
 

--- a/examples/ssd/caffe2npz.py
+++ b/examples/ssd/caffe2npz.py
@@ -74,6 +74,7 @@ def main():
     args = parser.parse_args()
 
     model = SSDCaffeFunction(args.caffemodel)
+
     # The pretrained weights are trained to accept BGR images.
     # Convert weights so that they accept RGB images.
     model['extractor/conv1_1'].W.data[:, ::-1] =\


### PR DESCRIPTION
New version shows how the layers are converted (BGR -> RGB, xy -> yx).
```
loading weights from VGG_VOC0712_SSD_300x300_iter_120000.caffemodel ...
conv1_1 -> extractor/conv1_1 (BGR -> RGB)
conv1_2 -> extractor/conv1_2
conv2_1 -> extractor/conv2_1
conv2_2 -> extractor/conv2_2
conv3_1 -> extractor/conv3_1
conv3_2 -> extractor/conv3_2
conv3_3 -> extractor/conv3_3
conv4_1 -> extractor/conv4_1
conv4_2 -> extractor/conv4_2
conv4_3 -> extractor/conv4_3
conv5_1 -> extractor/conv5_1
conv5_2 -> extractor/conv5_2
conv5_3 -> extractor/conv5_3
fc6 -> extractor/conv6
fc7 -> extractor/conv7
conv6_1 -> extractor/conv8_1
conv6_2 -> extractor/conv8_2
conv7_1 -> extractor/conv9_1
conv7_2 -> extractor/conv9_2
conv8_1 -> extractor/conv10_1
conv8_2 -> extractor/conv10_2
conv9_1 -> extractor/conv11_1
conv9_2 -> extractor/conv11_2
conv4_3_norm -> extractor/norm4
conv4_3_norm_mbox_loc -> multibox/loc/0 (xy -> yx)
conv4_3_norm_mbox_conf -> multibox/conf/0
fc7_mbox_loc -> multibox/loc/1 (xy -> yx)
fc7_mbox_conf -> multibox/conf/1
conv6_2_mbox_loc -> multibox/loc/2 (xy -> yx)
conv6_2_mbox_conf -> multibox/conf/2
conv7_2_mbox_loc -> multibox/loc/3 (xy -> yx)
conv7_2_mbox_conf -> multibox/conf/3
conv8_2_mbox_loc -> multibox/loc/4 (xy -> yx)
conv8_2_mbox_conf -> multibox/conf/4
conv9_2_mbox_loc -> multibox/loc/5 (xy -> yx)
conv9_2_mbox_conf -> multibox/conf/5
```