### PR TITLE
prevent duration = 0.0 and divding by zero

### DIFF
--- a/chainercv/utils/download.py
+++ b/chainercv/utils/download.py
@@ -21,6 +21,8 @@ def _reporthook(count, block_size, total_size):
         start_time = time.time()
         return
     duration = time.time() - start_time
+    if duration < 1e-4:
+        duration = 1e-4
     progress_size = int(count * block_size)
     speed = int(progress_size / (1024 * duration))
     percent = int(count * block_size * 100 / total_size)

--- a/chainercv/utils/download.py
+++ b/chainercv/utils/download.py
@@ -22,9 +22,9 @@ def _reporthook(count, block_size, total_size):
         return
     duration = time.time() - start_time
     progress_size = int(count * block_size)
-    if duration > 1e-4:
+    try:
         speed = int(progress_size / (1024 * duration))
-    else:
+    except ZeroDivisionError:
         speed = float('inf')
     percent = int(count * block_size * 100 / total_size)
     sys.stdout.write('\r...{}, {} MB, {} KB/s, {} seconds passed'.format(

--- a/chainercv/utils/download.py
+++ b/chainercv/utils/download.py
@@ -21,10 +21,11 @@ def _reporthook(count, block_size, total_size):
         start_time = time.time()
         return
     duration = time.time() - start_time
-    if duration < 1e-4:
-        duration = 1e-4
     progress_size = int(count * block_size)
-    speed = int(progress_size / (1024 * duration))
+    if duration > 1e-4:
+        speed = int(progress_size / (1024 * duration))
+    else:
+        speed = float('inf')
     percent = int(count * block_size * 100 / total_size)
     sys.stdout.write('\r...{}, {} MB, {} KB/s, {} seconds passed'.format(
         percent, progress_size / (1024 * 1024), speed, duration))


### PR DESCRIPTION
It is small bug. On my windows, it  occurs dividing zero 100%. It might occur on linux.

