### PR TITLE
Add cupy as a dependency for chainer2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,5 @@ dependencies:
   - numpy
   - Pillow
   - pip:
+    - cupy
     - chainer==2.0


### PR DESCRIPTION
Chainer 2 requires cupy as a separate dependency for CUDA support. It can work without CUDA support in CPU mode, so I'm not updating `environment_minimum.yml`.