### PR TITLE
Add version to chainercv.__init__.py

### DIFF
--- a/chainercv/__init__.py
+++ b/chainercv/__init__.py
@@ -1,3 +1,5 @@
+import pkg_resources
+
 from chainercv import datasets  # NOQA
 from chainercv import evaluations  # NOQA
 from chainercv import extensions  # NOQA
@@ -6,3 +8,6 @@ from chainercv import links  # NOQA
 from chainercv import transforms  # NOQA
 from chainercv import utils  # NOQA
 from chainercv import visualizations  # NOQA
+
+
+__version__ = pkg_resources.get_distribution('chainercv').version


### PR DESCRIPTION
This makes it convenient to access version of ChainerCV from Python code.

```python
>>> import chainercv
>>> chainercv.__version__
'0.5.1'
```