### PR TITLE
Fix test_assert_is_detection_link to always raise assert error

### DIFF
--- a/tests/utils_tests/testing_tests/assertions_tests/test_assert_is_detection_link.py
+++ b/tests/utils_tests/testing_tests/assertions_tests/test_assert_is_detection_link.py
@@ -16,7 +16,7 @@ class DetectionLink(chainer.Link):
         scores = list()
 
         for img in imgs:
-            n_bbox = np.random.randint(0, 10)
+            n_bbox = np.random.randint(1, 10)
             bboxes.append(generate_random_bbox(
                 n_bbox, img.shape[1:], 4, 12))
             labels.append(np.random.randint(


### PR DESCRIPTION

Undesired test error from #301
https://travis-ci.org/chainer/chainercv/jobs/247044467


```
======================================================================
FAIL: test_assert_is_detection_link (test_assert_is_detection_link.transplant_class.<locals>.C)  parameter: {'link': <test_assert_is_detection_link.InvalidScoreSizeLink object at 0x7f353a392908>, 'valid': False}
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/chainer/chainercv/tests/utils_tests/testing_tests/assertions_tests/test_assert_is_detection_link.py", line 76, in test_assert_is_detection_link
    assert_is_detection_link(self.link, 20)
AssertionError: AssertionError not raised
----------------------------------------------------------------------
Ran 305 tests in 43.523s
FAILED (failures=1)
```