### PR TITLE
Fix clip in Faster RCNN's predict

### DIFF
--- a/chainercv/links/model/faster_rcnn/faster_rcnn.py
+++ b/chainercv/links/model/faster_rcnn/faster_rcnn.py
@@ -304,10 +304,8 @@ class FasterRCNN(chainer.Chain):
             cls_bbox = loc2bbox(roi.reshape(-1, 4), roi_cls_loc.reshape(-1, 4))
             cls_bbox = cls_bbox.reshape(-1, self.n_class * 4)
             # clip bounding box
-            cls_bbox[:, slice(0, 4, 2)] = self.xp.clip(
-                cls_bbox[:, slice(0, 4, 2)], 0, H / scale)
-            cls_bbox[:, slice(1, 4, 2)] = self.xp.clip(
-                cls_bbox[:, slice(1, 4, 2)], 0, W / scale)
+            cls_bbox[:, 0::2] = self.xp.clip(cls_bbox[:, 0::2], 0, H / scale)
+            cls_bbox[:, 1::2] = self.xp.clip(cls_bbox[:, 1::2], 0, W / scale)
 
             prob = F.softmax(roi_score).data
 

--- a/examples/detection/README.md
+++ b/examples/detection/README.md
@@ -13,7 +13,7 @@ For the details, please check the documents and examples of each model.
 
 | Model | Train dataset | FPS | mAP (PASCAL VOC2007 metric) |
 |:-:|:-:|:-:|:-:|
-| Faster R-CNN | VOC2007 trainval | | 70.5 % |
+| Faster R-CNN | VOC2007 trainval | | 70.6 % |
 | SSD300 | VOC2007\&2012 trainval | | 77.8 % |
 | SSD512 | VOC2007\&2012 trainval | | 79.7 % |
 

--- a/examples/faster_rcnn/README.md
+++ b/examples/faster_rcnn/README.md
@@ -4,7 +4,7 @@
 
 | Training Setting | Evaluation | Reference | ChainerCV |
 |:-:|:-:|:-:|:-:|
-| VOC 2007 trainval | VOC 2007 test|  69.9 mAP [1] | 70.5 mAP |
+| VOC 2007 trainval | VOC 2007 test|  69.9 mAP [1] | 70.6 mAP |
 
 
 ### Speed


### PR DESCRIPTION
Fix #318.

The performance of Faster R-CNN improved by 0.1 mAP.


```
$ python eval_voc07.py --model faster_rcnn

mAP: 0.706190
aeroplane: 0.727936
bicycle: 0.785589
bird: 0.683971
boat: 0.544837
bottle: 0.545018
bus: 0.797693
car: 0.801092
cat: 0.791231
chair: 0.535096
cow: 0.762753
diningtable: 0.690102
dog: 0.809668
horse: 0.802017
motorbike: 0.759324
person: 0.773646
pottedplant: 0.452792
sheep: 0.720949
sofa: 0.660239
train: 0.758600
tvmonitor: 0.721254

```