### PR TITLE
install Cython and numpy manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ These are the outputs of the detection models supported by ChainerCV.
 
 # Installation
 
+Install `Cython` and `numpy` first.
+
+```
+$ pip install Cython
+$ pip install numpy
+```
+
+Install `chainercv`.
+
 ```
 $ pip install chainercv
 ```

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ cmdclass = {'build_ext': build_ext}
 
 install_requires = [
     'chainer==2.0',
-    'Cython',
     'Pillow'
 ]
 


### PR DESCRIPTION
@yuyu2172 
Because you use `numpy` and `Cython` in `setup.py`, we need to install them manually before running `pip install chainercv`

You can test it like
```bash
docker pull ubuntu
docker run -it ubuntu /bin/bash
# in docker session
apt-get update
apt-get install python-pip
pip install -U pip
pip install chainercv
# installation fails

pip install Cython
pip install numpy
pip install chainercv
# you can successfully install chainercv
```

Related https://github.com/ros/rosdistro/pull/15441