### PR TITLE
Stop using invoke_before_training option in Faster R-CNN example

### DIFF
--- a/examples/faster_rcnn/train.py
+++ b/examples/faster_rcnn/train.py
@@ -123,8 +123,7 @@ def main():
             test_iter, model.faster_rcnn, use_07_metric=True,
             label_names=voc_detection_label_names),
         trigger=ManualScheduleTrigger(
-            [args.step_size, args.iteration], 'iteration'),
-        invoke_before_training=False)
+            [args.step_size, args.iteration], 'iteration'))
 
     trainer.extend(extensions.dump_graph('main/loss'))
 


### PR DESCRIPTION
Related #338