### PR TITLE
Show in legend only classes that appear in an image for vis_label

### DIFF
--- a/chainercv/visualizations/vis_label.py
+++ b/chainercv/visualizations/vis_label.py
@@ -67,8 +67,9 @@ def vis_label(
             overlaying the label on the source image.
         all_label_names_in_legend (bool): Determines whether to include
             all label names in a legend. If this is :obj:`False`,
-            only the names of labels
-            that are included in the label image are included.
+            the legend does not contain the names of unused labels.
+            An unused label is defined as a label that does not appear in
+            :obj:`label`.
             The default value is :obj:`False`.
         ax (matplotlib.axes.Axis): The visualization is displayed on this
             axis. If this is :obj:`None` (default), a new axis is created.

--- a/chainercv/visualizations/vis_label.py
+++ b/chainercv/visualizations/vis_label.py
@@ -116,6 +116,8 @@ def vis_label(
 
     legend_handles = list()
     for l in np.unique(label):
+        if l < 0:
+            continue
         legend_handles.append(
             Patch(color=cmap(l / (n_class - 1)), label=label_names[l]))
 

--- a/chainercv/visualizations/vis_label.py
+++ b/chainercv/visualizations/vis_label.py
@@ -115,8 +115,8 @@ def vis_label(
     ax.imshow(img)
 
     legend_handles = list()
-    for l, label_name in enumerate(label_names):
+    for l in np.unique(label):
         legend_handles.append(
-            Patch(color=cmap(l / (n_class - 1)), label=label_name))
+            Patch(color=cmap(l / (n_class - 1)), label=label_names[l]))
 
     return ax, legend_handles

--- a/chainercv/visualizations/vis_label.py
+++ b/chainercv/visualizations/vis_label.py
@@ -20,7 +20,8 @@ def _default_cmap(label):
 
 def vis_label(
         label, label_names=None,
-        label_colors=None, ignore_label_color=(0, 0, 0), alpha=1, ax=None):
+        label_colors=None, ignore_label_color=(0, 0, 0), alpha=1,
+        all_label_names_in_legend=False, ax=None):
     """Visualize a label for semantic segmentation.
 
     Example:
@@ -64,6 +65,11 @@ def vis_label(
             value is :obj:`0`, the figure will be completely transparent.
             The default value is :obj:`1`. This option is useful for
             overlaying the label on the source image.
+        all_label_names_in_legend (bool): Determines whether to include
+            all label names in a legend. If this is :obj:`False`,
+            only the names of labels
+            that are included in the label image are included.
+            The default value is :obj:`False`.
         ax (matplotlib.axes.Axis): The visualization is displayed on this
             axis. If this is :obj:`None` (default), a new axis is created.
 
@@ -115,9 +121,11 @@ def vis_label(
     ax.imshow(img)
 
     legend_handles = list()
-    for l in np.unique(label):
-        if l < 0:
-            continue
+    if all_label_names_in_legend:
+        legend_labels = [l for l in np.unique(label) if l >= 0]
+    else:
+        legend_labels = list(range(len(label_names)))
+    for l in legend_labels:
         legend_handles.append(
             Patch(color=cmap(l / (n_class - 1)), label=label_names[l]))
 

--- a/chainercv/visualizations/vis_label.py
+++ b/chainercv/visualizations/vis_label.py
@@ -125,7 +125,7 @@ def vis_label(
     if all_label_names_in_legend:
         legend_labels = [l for l in np.unique(label) if l >= 0]
     else:
-        legend_labels = range(len(label_names))
+        legend_labels = range(n_class)
     for l in legend_labels:
         legend_handles.append(
             Patch(color=cmap(l / (n_class - 1)), label=label_names[l]))

--- a/chainercv/visualizations/vis_label.py
+++ b/chainercv/visualizations/vis_label.py
@@ -124,7 +124,7 @@ def vis_label(
     if all_label_names_in_legend:
         legend_labels = [l for l in np.unique(label) if l >= 0]
     else:
-        legend_labels = list(range(len(label_names)))
+        legend_labels = range(len(label_names))
     for l in legend_labels:
         legend_handles.append(
             Patch(color=cmap(l / (n_class - 1)), label=label_names[l]))

--- a/tests/visualizations_tests/test_vis_label.py
+++ b/tests/visualizations_tests/test_vis_label.py
@@ -15,6 +15,7 @@ except ImportError:
 @testing.parameterize(*testing.product({
     'label_names': [None, ('class0', 'class1', 'class2')],
     'label_colors': [None, ((255, 0, 0), (0, 255, 0), (0, 0, 255))],
+    'all_label_names_in_legend': [False, True],
 }))
 class TestVisLabel(unittest.TestCase):
 
@@ -26,7 +27,8 @@ class TestVisLabel(unittest.TestCase):
         if optional_modules:
             ax, legend_handles = vis_label(
                 self.label,
-                label_names=self.label_names, label_colors=self.label_colors)
+                label_names=self.label_names, label_colors=self.label_colors,
+                all_label_names_in_legend=self.all_label_names_in_legend)
 
             self.assertIsInstance(ax, matplotlib.axes.Axes)
             for handle in legend_handles:


### PR DESCRIPTION
There is not much point in showing legends for all the classes in a dataset.
Similar to `vis_bbox`, `vis_label` should limit information to the one that is contained in an image.


## Example
This dataset contains 80 classes.

#### Before
![figure_1-2](https://user-images.githubusercontent.com/2062128/28355611-b34575ec-6c9f-11e7-8ad6-45a8a3dbf21e.png)


#### After
![figure_1](https://user-images.githubusercontent.com/2062128/28355528-5c153244-6c9f-11e7-8f1b-cf70b80c2e4a.png)
