### PR TITLE
Sequential feature extractor remove_unused

### DIFF
--- a/chainercv/links/model/sequential_feature_extractor.py
+++ b/chainercv/links/model/sequential_feature_extractor.py
@@ -111,14 +111,12 @@ class SequentialFeatureExtractor(chainer.Chain):
 
         """
         if self._feature_names is None:
-            feature_names = (self.all_feature_names[-1],)
-        else:
-            feature_names = self._feature_names
+            return
 
         # The biggest index among indices of the features that are included
         # in feature_names.
         last_index = max(self.all_feature_names.index(name) for
-                         name in feature_names)
+                         name in self._feature_names)
         for name in self.all_feature_names[last_index + 1:]:
             delattr(self, name)
 

--- a/chainercv/links/model/sequential_feature_extractor.py
+++ b/chainercv/links/model/sequential_feature_extractor.py
@@ -107,7 +107,7 @@ class SequentialFeatureExtractor(chainer.Chain):
         self._feature_names = tuple(feature_names)
 
     def remove_unused(self):
-        """Delete all features that are not needed for the forward pass.
+        """Delete all layers that are not needed for the forward pass.
 
         """
         if self._feature_names is None:

--- a/chainercv/links/model/sequential_feature_extractor.py
+++ b/chainercv/links/model/sequential_feature_extractor.py
@@ -43,6 +43,11 @@ class SequentialFeatureExtractor(chainer.Chain):
         >>> # These are features l2_relu and l1_relu.
         >>> feat2, feat1 = model(x)
 
+        >>> # The sequence can be indexed using an integer or a slice.
+        >>> bottom_model = model[:2]
+        >>> bottom_model.all_feature_names
+        ['l1', 'l1_relu']
+
     Parameters:
         feature_names (string or iterable of strings):
             Names of features that are collected during
@@ -105,6 +110,22 @@ class SequentialFeatureExtractor(chainer.Chain):
 
         self._return_tuple = return_tuple
         self._feature_names = tuple(feature_names)
+
+    def __getitem__(self, index):
+        if isinstance(index, int):
+            return getattr(self, self.all_feature_names[index])
+        elif isinstance(index, slice):
+            ret = self.copy()
+            keep_feature_names = self.all_feature_names[index]
+            for name in list(self.all_feature_names):
+                if name not in keep_feature_names:
+                    delattr(ret, name)
+            return ret
+        else:
+            return super(SequentialFeatureExtractor, self).__getitem__(index)
+
+    def index(self, name):
+        return self.all_feature_names.index(name)
 
     def __call__(self, x):
         """Forward this model.

--- a/tests/links_tests/model_tests/test_sequential_feature_extractor.py
+++ b/tests/links_tests/model_tests/test_sequential_feature_extractor.py
@@ -125,10 +125,11 @@ class TestSequentialFeatureExtractor(unittest.TestCase):
 
 
 @testing.parameterize(
+    {'feature_names': 'f1', 'index': 1, 'all_feature_names': None},
     {'feature_names': 'f1', 'index': slice(None, 2),
      'all_feature_names': ['l1', 'f1']},
-    {'feature_names': 'f1', 'index': 1, 'all_feature_names': None},
-    {'feature_names': 'f2', 'index': slice(2, -1), 'all_feature_names': ['f2']}
+    {'feature_names': 'f2', 'index': slice(2, -1), 'all_feature_names': ['f2']},
+    {'feature_names': 'l1', 'index': slice(None, 2, 2), 'all_feature_names': ['l1']}
 )
 class TestSequentialFeatureExtractorGetitem(unittest.TestCase):
 

--- a/tests/links_tests/model_tests/test_sequential_feature_extractor.py
+++ b/tests/links_tests/model_tests/test_sequential_feature_extractor.py
@@ -128,8 +128,10 @@ class TestSequentialFeatureExtractor(unittest.TestCase):
     {'feature_names': 'f1', 'index': 1, 'all_feature_names': None},
     {'feature_names': 'f1', 'index': slice(None, 2),
      'all_feature_names': ['l1', 'f1']},
-    {'feature_names': 'f2', 'index': slice(2, -1), 'all_feature_names': ['f2']},
-    {'feature_names': 'l1', 'index': slice(None, 2, 2), 'all_feature_names': ['l1']}
+    {'feature_names': 'f2', 'index': slice(2, -1),
+     'all_feature_names': ['f2']},
+    {'feature_names': 'l1', 'index': slice(None, 2, 2),
+     'all_feature_names': ['l1']}
 )
 class TestSequentialFeatureExtractorGetitem(unittest.TestCase):
 

--- a/tests/links_tests/model_tests/test_sequential_feature_extractor.py
+++ b/tests/links_tests/model_tests/test_sequential_feature_extractor.py
@@ -125,15 +125,10 @@ class TestSequentialFeatureExtractor(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'feature_names': 'f1',
-     'index': slice(None, 2),
+    {'feature_names': 'f1', 'index': slice(None, 2),
      'all_feature_names': ['l1', 'f1']},
-    {'feature_names': 'f1',
-     'index': 1,
-     'all_feature_names': ['l1', 'f1']},
-    {'feature_names': 'f2',
-     'index': slice(2, -1),
-     'all_feature_names': ['f2']}
+    {'feature_names': 'f1', 'index': 1, 'all_feature_names': None},
+    {'feature_names': 'f2', 'index': slice(2, -1), 'all_feature_names': ['f2']}
 )
 class TestSequentialFeatureExtractorGetitem(unittest.TestCase):
 

--- a/tests/links_tests/model_tests/test_sequential_feature_extractor.py
+++ b/tests/links_tests/model_tests/test_sequential_feature_extractor.py
@@ -126,10 +126,13 @@ class TestSequentialFeatureExtractor(unittest.TestCase):
 
 @testing.parameterize(
     {'feature_names': 'f1',
-     'slice': slice(None, 2),
+     'index': slice(None, 2),
+     'all_feature_names': ['l1', 'f1']},
+    {'feature_names': 'f1',
+     'index': 1,
      'all_feature_names': ['l1', 'f1']},
     {'feature_names': 'f2',
-     'slice': slice(2, -1),
+     'index': slice(2, -1),
      'all_feature_names': ['f2']}
 )
 class TestSequentialFeatureExtractorGetitem(unittest.TestCase):
@@ -149,8 +152,13 @@ class TestSequentialFeatureExtractorGetitem(unittest.TestCase):
         self.link.feature_names = self.feature_names
 
     def check_getitem(self):
-        model = self.link[self.slice]
-        self.assertEqual(model.all_feature_names, self.all_feature_names)
+        ret = self.link[self.index]
+        if isinstance(self.index, int):
+            expected_type = type(getattr(
+                self.link, self.link.all_feature_names[self.index]))
+            self.assertIsInstance(ret, expected_type)
+        elif isinstance(self.index, slice):
+            self.assertEqual(ret.all_feature_names, self.all_feature_names)
 
     def test_getitem_cpu(self):
         self.check_getitem()


### PR DESCRIPTION
Merge after #347 .

I found that it is beneficial to have a method that chops off unnecessary part from a feature extractor.
For instance, an optimizer hook is called for all parameters even if they are not used in a computational graph.