### PR TITLE
Fix Chainer version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ python:
   - "2.7"
   - "3.6"
 env:
-  - CHAINER_VERSION="2.0" OPTIONAL_MODULES=0
-  - CHAINER_VERSION="2.0" OPTIONAL_MODULES=1
-  - CHAINER_VERSION="3.0.0a1" OPTIONAL_MODULES=0
-  - CHAINER_VERSION="3.0.0a1" OPTIONAL_MODULES=1
+  - CHAINER_VERSION=">=2.0" OPTIONAL_MODULES=0
+  - CHAINER_VERSION=">=2.0" OPTIONAL_MODULES=1
+  - CHAINER_VERSION="==3.0.0a1" OPTIONAL_MODULES=0
+  - CHAINER_VERSION="==3.0.0a1" OPTIONAL_MODULES=1
 notifications:
   email: false
 
@@ -34,7 +34,7 @@ install:
       source activate chainercv_minimum;
     fi
   - pip install -e .
-  - pip install chainer=="$CHAINER_VERSION"
+  - pip install "chainer$CHAINER_VERSION"
 
 script:
   - pwd


### PR DESCRIPTION
Another version of #349. In this version, we don't have to update miner version of v2.