### PR TITLE
Remove matplotlib backend specification line from example code

### DIFF
--- a/examples/faster_rcnn/README.md
+++ b/examples/faster_rcnn/README.md
@@ -51,7 +51,7 @@ You can train the model with the following code.
 $ python train.py [--gpu <gpu>]
 ```
 
-If you got `RuntimeError: Invalid DISPLAY variable` error on Linux environment, adding an environment variable specification is recommended:
+PlotReport extension uses matplotlib. If you got `RuntimeError: Invalid DISPLAY variable` error on Linux environment, adding an environment variable specification is recommended:
 
 ```
 $ MPLBACKEND=Agg python train.py [--gpu <gpu>]

--- a/examples/faster_rcnn/README.md
+++ b/examples/faster_rcnn/README.md
@@ -51,6 +51,12 @@ You can train the model with the following code.
 $ python train.py [--gpu <gpu>]
 ```
 
+If you got `RuntimeError: Invalid DISPLAY variable` error on Linux environment, adding an environmental variable specification is recommended:
+
+```
+$ MPLBACKEND=Agg python train.py [--gpu <gpu>]
+```
+
 
 ### Evaluation
 

--- a/examples/faster_rcnn/README.md
+++ b/examples/faster_rcnn/README.md
@@ -51,7 +51,7 @@ You can train the model with the following code.
 $ python train.py [--gpu <gpu>]
 ```
 
-If you got `RuntimeError: Invalid DISPLAY variable` error on Linux environment, adding an environmental variable specification is recommended:
+If you got `RuntimeError: Invalid DISPLAY variable` error on Linux environment, adding an environment variable specification is recommended:
 
 ```
 $ MPLBACKEND=Agg python train.py [--gpu <gpu>]

--- a/examples/faster_rcnn/train.py
+++ b/examples/faster_rcnn/train.py
@@ -1,10 +1,5 @@
 from __future__ import division
 
-try:
-    import matplotlib
-except ImportError:
-    pass
-
 import argparse
 import numpy as np
 

--- a/examples/faster_rcnn/train.py
+++ b/examples/faster_rcnn/train.py
@@ -2,7 +2,6 @@ from __future__ import division
 
 try:
     import matplotlib
-    matplotlib.use('agg')
 except ImportError:
     pass
 

--- a/examples/segnet/README.md
+++ b/examples/segnet/README.md
@@ -17,7 +17,7 @@ First, move to this directory (i.e., `examples/segnet`) and run:
 python train.py [--gpu <gpu>]
 ```
 
-If you got `RuntimeError: Invalid DISPLAY variable` error on Linux environment, adding an environment variable specification is recommended:
+PlotReport extension uses matplotlib. If you got `RuntimeError: Invalid DISPLAY variable` error on Linux environment, adding an environment variable specification is recommended:
 
 ```
 $ MPLBACKEND=Agg python train.py [--gpu <gpu>]

--- a/examples/segnet/README.md
+++ b/examples/segnet/README.md
@@ -17,6 +17,12 @@ First, move to this directory (i.e., `examples/segnet`) and run:
 python train.py [--gpu <gpu>]
 ```
 
+If you got `RuntimeError: Invalid DISPLAY variable` error on Linux environment, adding an environment variable specification is recommended:
+
+```
+$ MPLBACKEND=Agg python train.py [--gpu <gpu>]
+```
+
 ## NOTE
 
 - According to the original implementation, the authors performed LR flipping to the input images for data augmentation: https://github.com/alexgkendall/caffe-segnet/blob/segnet-cleaned/src/caffe/layers/dense_image_data_layer.cpp#L168-L175
@@ -83,5 +89,5 @@ The above values of the official implementation is found here: [Getting Started 
 
 # Reference
 
-1. Vijay Badrinarayanan, Alex Kendall and Roberto Cipolla "SegNet: A Deep Convolutional Encoder-Decoder Architecture for Image Segmentation." PAMI, 2017. 
+1. Vijay Badrinarayanan, Alex Kendall and Roberto Cipolla "SegNet: A Deep Convolutional Encoder-Decoder Architecture for Image Segmentation." PAMI, 2017.
 2. Vijay Badrinarayanan, Ankur Handa and Roberto Cipolla "SegNet: A Deep Convolutional Encoder-Decoder Architecture for Robust Semantic Pixel-Wise Labelling." arXiv preprint arXiv:1505.07293, 2015.

--- a/examples/segnet/train.py
+++ b/examples/segnet/train.py
@@ -1,6 +1,5 @@
 try:
     import matplotlib
-    matplotlib.use('Agg')
 except ImportError:
     pass
 

--- a/examples/segnet/train.py
+++ b/examples/segnet/train.py
@@ -1,8 +1,3 @@
-try:
-    import matplotlib
-except ImportError:
-    pass
-
 import argparse
 
 import chainer


### PR DESCRIPTION
`matplotlib.use('Agg')` sometimes causes problems in some environments. (ref. https://github.com/chainer/chainer/issues/2146)
Just using the environmental variable in this way:
`MPLBACKEND=Agg python train.py`
is preferred. This PR updates the faster-rcnn example in this way.