### PR TITLE
Support Chainer 2.0.1 and 3.0.0a1

### DIFF
--- a/examples/ssd/caffe2npz.py
+++ b/examples/ssd/caffe2npz.py
@@ -47,17 +47,17 @@ class SSDCaffeFunction(caffe.CaffeFunction):
         print('loading weights from {:s} ... '.format(model_path))
         super(SSDCaffeFunction, self).__init__(model_path)
 
-    def __setattr__(self, name, link):
-        if self.within_init_scope and isinstance(link, Link):
+    def __setattr__(self, name, value):
+        if self.within_init_scope and isinstance(value, Link):
             new_name = rename(name)
 
             if new_name == 'extractor/conv1_1':
                 # BGR -> RGB
-                link.W.data[:, ::-1] = link.W.data
+                value.W.data[:, ::-1] = value.W.data
                 print('{:s} -> {:s} (BGR -> RGB)'.format(name, new_name))
             elif new_name.startswith('multibox/loc/'):
                 # xy -> yx
-                for data in (link.W.data, link.b.data):
+                for data in (value.W.data, value.b.data):
                     data = data.reshape((-1, 4) + data.shape[1:])
                     data[:, [1, 0, 3, 2]] = data.copy()
                 print('{:s} -> {:s} (xy -> yx)'.format(name, new_name))
@@ -66,7 +66,7 @@ class SSDCaffeFunction(caffe.CaffeFunction):
         else:
             new_name = name
 
-        super(SSDCaffeFunction, self).__setattr__(new_name, link)
+        super(SSDCaffeFunction, self).__setattr__(new_name, value)
 
     @caffe._layer('Normalize', None)
     def _setup_normarize(self, layer):

--- a/examples/ssd/caffe2npz.py
+++ b/examples/ssd/caffe2npz.py
@@ -2,6 +2,7 @@ import argparse
 import numpy as np
 import re
 
+from chainer import Link
 import chainer.links.caffe.caffe_function as caffe
 from chainer import serializers
 
@@ -47,7 +48,7 @@ class SSDCaffeFunction(caffe.CaffeFunction):
         super(SSDCaffeFunction, self).__init__(model_path)
 
     def __setattr__(self, name, link):
-        if self.within_init_scope and name != '_within_init_scoep':
+        if self.within_init_scope and instanceof(link, Link):
             new_name = rename(name)
 
             if new_name == 'extractor/conv1_1':

--- a/examples/ssd/caffe2npz.py
+++ b/examples/ssd/caffe2npz.py
@@ -48,7 +48,7 @@ class SSDCaffeFunction(caffe.CaffeFunction):
         super(SSDCaffeFunction, self).__init__(model_path)
 
     def __setattr__(self, name, link):
-        if self.within_init_scope and instanceof(link, Link):
+        if self.within_init_scope and isinstance(link, Link):
             new_name = rename(name)
 
             if new_name == 'extractor/conv1_1':

--- a/examples/ssd/caffe2npz.py
+++ b/examples/ssd/caffe2npz.py
@@ -47,7 +47,7 @@ class SSDCaffeFunction(caffe.CaffeFunction):
         super(SSDCaffeFunction, self).__init__(model_path)
 
     def __setattr__(self, name, link):
-        if self.within_init_scope:
+        if self.within_init_scope and name != '_within_init_scoep':
             new_name = rename(name)
 
             if new_name == 'extractor/conv1_1':

--- a/examples/ssd/caffe2npz.py
+++ b/examples/ssd/caffe2npz.py
@@ -36,6 +36,8 @@ def rename(name):
         i, type_ = int(m.group(1)), m.group(2)
         if i >= 6:
             return 'multibox/{:s}/{:d}'.format(type_, i - 4), True
+        else:
+            return name, True
 
     return name, False
 

--- a/examples/ssd/caffe2npz.py
+++ b/examples/ssd/caffe2npz.py
@@ -14,30 +14,30 @@ def rename(name):
         i, j = map(int, m.groups())
         if i >= 6:
             i += 2
-        return 'extractor/conv{:d}_{:d}'.format(i, j)
+        return 'extractor/conv{:d}_{:d}'.format(i, j), True
 
     m = re.match(r'fc([67])$', name)
     if m:
-        return 'extractor/conv{:d}'.format(int(m.group(1)))
+        return 'extractor/conv{:d}'.format(int(m.group(1))), True
 
     if name == r'conv4_3_norm':
-        return 'extractor/norm4'
+        return 'extractor/norm4', True
 
     m = re.match(r'conv4_3_norm_mbox_(loc|conf)$', name)
     if m:
-        return 'multibox/{:s}/0'.format(m.group(1))
+        return 'multibox/{:s}/0'.format(m.group(1)), True
 
     m = re.match(r'fc7_mbox_(loc|conf)$', name)
     if m:
-        return ('multibox/{:s}/1'.format(m.group(1)))
+        return ('multibox/{:s}/1'.format(m.group(1))), True
 
     m = re.match(r'conv(\d+)_2_mbox_(loc|conf)$', name)
     if m:
         i, type_ = int(m.group(1)), m.group(2)
         if i >= 6:
-            return 'multibox/{:s}/{:d}'.format(type_, i - 4)
+            return 'multibox/{:s}/{:d}'.format(type_, i - 4), True
 
-    return name
+    return name, False
 
 
 class SSDCaffeFunction(caffe.CaffeFunction):
@@ -46,8 +46,8 @@ class SSDCaffeFunction(caffe.CaffeFunction):
         print('loading weights from {:s} ... '.format(model_path))
         super(SSDCaffeFunction, self).__init__(model_path)
 
-    def add_link(self, name, link):
-        new_name = rename(name)
+    def __setattr__(self, name, link):
+        new_name, match = rename(name)
 
         if new_name == 'extractor/conv1_1':
             # BGR -> RGB
@@ -59,17 +59,18 @@ class SSDCaffeFunction(caffe.CaffeFunction):
                 data = data.reshape((-1, 4) + data.shape[1:])
                 data[:, [1, 0, 3, 2]] = data.copy()
             print('{:s} -> {:s} (xy -> yx)'.format(name, new_name))
-        else:
+        elif match:
             print('{:s} -> {:s}'.format(name, new_name))
 
-        super(SSDCaffeFunction, self).add_link(new_name, link)
+        super(SSDCaffeFunction, self).__setattr__(new_name, link)
 
     @caffe._layer('Normalize', None)
     def _setup_normarize(self, layer):
         blobs = layer.blobs
         func = Normalize(caffe._get_num(blobs[0]))
         func.scale.data[:] = np.array(blobs[0].data)
-        self.add_link(layer.name, func)
+        with self.init_scope():
+            setattr(self, layer.name, func)
 
     @caffe._layer('AnnotatedData', None)
     @caffe._layer('Flatten', None)


### PR DESCRIPTION
`chainer.links.caffe.CaffeFunction.add_link` has been [deprecated](https://docs.chainer.org/en/latest/reference/generated/chainer.links.caffe.CaffeFunction.html#chainer.links.caffe.CaffeFunction.add_link) since 2.0.0, and `chainer.links.caffe.CaffeFunction` no longer calls `self.add_link` since [this commit](https://github.com/chainer/chainer/pull/2947/files) was merged.

I switched from overriding `add_link` to overriding `__setattr__` so that it can run in Chainer 2.0.1 or later.

This PR is almost the same as [this](https://github.com/Hakuyume/chainer-ssd/pull/10).