### PR TITLE
Fix use_gpu in examples

### DIFF
--- a/examples/faster_rcnn/demo.py
+++ b/examples/faster_rcnn/demo.py
@@ -23,8 +23,8 @@ def main():
         pretrained_model=args.pretrained_model)
 
     if args.gpu >= 0:
-        model.to_gpu(args.gpu)
         chainer.cuda.get_device(args.gpu).use()
+        model.to_gpu()
 
     img = utils.read_image(args.image, color=True)
     bboxes, labels, scores = model.predict([img])

--- a/examples/faster_rcnn/train.py
+++ b/examples/faster_rcnn/train.py
@@ -61,8 +61,8 @@ def main():
     faster_rcnn.use_preset('evaluate')
     model = FasterRCNNTrainChain(faster_rcnn)
     if args.gpu >= 0:
-        model.to_gpu(args.gpu)
         chainer.cuda.get_device(args.gpu).use()
+        model.to_gpu()
     optimizer = chainer.optimizers.MomentumSGD(lr=args.lr, momentum=0.9)
     optimizer.setup(model)
     optimizer.add_hook(chainer.optimizer.WeightDecay(rate=0.0005))

--- a/examples/segnet/demo.py
+++ b/examples/segnet/demo.py
@@ -25,8 +25,8 @@ def main():
         pretrained_model=args.pretrained_model)
 
     if args.gpu >= 0:
-        model.to_gpu(args.gpu)
         chainer.cuda.get_device(args.gpu).use()
+        model.to_gpu()
 
     img = utils.read_image(args.image, color=True)
     labels = model.predict([img])

--- a/examples/segnet/eval_camvid.py
+++ b/examples/segnet/eval_camvid.py
@@ -50,7 +50,8 @@ def main():
         n_class=len(camvid_label_names),
         pretrained_model=args.pretrained_model)
     if args.gpu >= 0:
-        model.to_gpu(args.gpu)
+        chainer.cuda.get_device(args.gpu).use()
+        model.to_gpu()
 
     model = calc_bn_statistics(model, args.batchsize)
 


### PR DESCRIPTION
`examples/segnet/eval_camvid.py` fails if `args.gpu > 0`. I fixed this bug by adding `chainer.cuda.get_device(args.gpu).use()`. Other modifications are only for consistency.