### PR TITLE
Report statistics of train performance for SegNet and Faster RCNN

### DIFF
--- a/examples/faster_rcnn/README.md
+++ b/examples/faster_rcnn/README.md
@@ -4,7 +4,12 @@
 
 | Training Setting | Evaluation | Reference | ChainerCV |
 |:-:|:-:|:-:|:-:|
-| VOC 2007 trainval | VOC 2007 test|  69.9 mAP [1] | 70.6 mAP |
+| VOC 2007 trainval | VOC 2007 test|  69.9 % [1] | 70.29 % (0.50%) |
+
+Scores are mean Average Precision (mAP) with PASCAL VOC2007 metric.
+
+For the scores reported for ChainerCV, they are the mean of five trials.
+The standard deviation is in parentheses.
 
 
 ### Speed
@@ -62,6 +67,22 @@ $ MPLBACKEND=Agg python train.py [--gpu <gpu>]
 
 The evaluation score is reported by `DetectionVOCEvaluator` during training.
 Also, the evaluation can be conducted outside of training loop by using [`chainercv/examples/detection/eval_voc07.py`](https://github.com/chainer/chainercv/blob/master/examples/detection).
+
+
+### Trained weights
+
+Here are links to the weights trained using ChainerCV.
+
+##### Faster RCNN VGG16 trained with VOC07
+
+[1](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_0.npz) 
+[2](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_1.npz) 
+[3](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_2.npz) 
+[4](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_3.npz) 
+[5](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_4.npz)
+
+[2](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_1.npz) scored the median mAP (70.24%).
+
 
 
 ### References

--- a/examples/faster_rcnn/README.md
+++ b/examples/faster_rcnn/README.md
@@ -75,14 +75,13 @@ Here are links to the weights trained using ChainerCV.
 
 ##### Faster RCNN VGG16 trained with VOC07
 
-[1](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_0.npz) 
-[2](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_1.npz) 
-[3](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_2.npz) 
-[4](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_3.npz) 
-[5](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_4.npz)
-
-[2](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_1.npz) scored the median mAP (70.24%).
-
+| Trial | mAP |
+|:-:|:-:|
+|  [1](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_0.npz) | 70.21 % |
+|  [2](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_1.npz) | 70.23 % |
+|  [3](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_2.npz) | 69.44 % |
+|  [4](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_3.npz) | 70.94 % |
+|  [5](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/faster_rcnn_vgg16_voc07_trained_2017_08_06_trial_4.npz) | 70.62 % |
 
 
 ### References

--- a/examples/segnet/README.md
+++ b/examples/segnet/README.md
@@ -82,10 +82,30 @@ Global average accuracy : 0.8266
 
 | Implementation | Global accuracy | Class accuracy | mean IoU   |
 |:--------------:|:---------------:|:--------------:|:----------:|
-| ChainerCV      | 82.7 %          | **67.1 %**     | **49.4 %** |
+| ChainerCV      | 81.08 % (2.44%)   | **65.92 %** (1.11%)  | **47.81 %** (2.52%) |
 | Official       | **82.8 %**      | 62.3%          | 46.3 %     |
 
 The above values of the official implementation is found here: [Getting Started with SegNet](http://mi.eng.cam.ac.uk/projects/segnet/tutorial.html)
+
+For the scores reported for ChainerCV, they are the means of five trials.
+The standard deviations are in parentheses.
+
+
+
+## Trained weights
+
+Here are links to the weights trained using ChainerCV.
+
+##### SegNet traiend with CamVid
+
+[1](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/segnet_camvid_trained_2017_08_06_trial_0.npz) 
+[2](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/segnet_camvid_trained_2017_08_06_trial_1.npz) 
+[3](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/segnet_camvid_trained_2017_08_06_trial_2.npz) 
+[4](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/segnet_camvid_trained_2017_08_06_trial_3.npz) 
+[5](https://github.com/yuyu2172/share-weights/releases/download/0.0.2/segnet_camvid_2017_05_28.npz)
+
+[5](https://github.com/yuyu2172/share-weights/releases/download/0.0.2/segnet_camvid_2017_05_28.npz)  scored the median mIoU (49.39%).
+
 
 # Reference
 

--- a/examples/segnet/README.md
+++ b/examples/segnet/README.md
@@ -98,13 +98,13 @@ Here are links to the weights trained using ChainerCV.
 
 ##### SegNet traiend with CamVid
 
-[1](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/segnet_camvid_trained_2017_08_06_trial_0.npz) 
-[2](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/segnet_camvid_trained_2017_08_06_trial_1.npz) 
-[3](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/segnet_camvid_trained_2017_08_06_trial_2.npz) 
-[4](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/segnet_camvid_trained_2017_08_06_trial_3.npz) 
-[5](https://github.com/yuyu2172/share-weights/releases/download/0.0.2/segnet_camvid_2017_05_28.npz)
-
-[5](https://github.com/yuyu2172/share-weights/releases/download/0.0.2/segnet_camvid_2017_05_28.npz)  scored the median mIoU (49.39%).
+| Trial | Global accuracy | Class accuracy | mean IoU   |
+|:--------------:|:---------------:|:--------------:|:---------------:|
+| [1](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/segnet_camvid_trained_2017_08_06_trial_0.npz)  | 78.33 % | 65.45 % | 45.81% |
+|[2](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/segnet_camvid_trained_2017_08_06_trial_1.npz) | 77.88 % | 64.22% | 43.86%|
+|[3](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/segnet_camvid_trained_2017_08_06_trial_2.npz) | 83.18 % | 67.24% | 50.08%|
+|[4](https://github.com/yuyu2172/share-weights/releases/download/0.0.4/segnet_camvid_trained_2017_08_06_trial_3.npz) | 83.34 % | 65.64% | 49.93%|
+|[5](https://github.com/yuyu2172/share-weights/releases/download/0.0.2/segnet_camvid_2017_05_28.npz) | 82.66% | 67.05 % | 49.39%|
 
 
 # Reference


### PR DESCRIPTION
Here are scores I used to calculate the statistics.
Please merge this after merging #265.
The weights for Faster R-CNN are not compatible with master branch.

# Faster R-CNN VGG16 VOC07 trained

### Trial 1
mAP: 0.702103

### Trial 2
mAP: 0.702370

### Trial 3
mAP: 0.694398

### Trial 4
mAP: 0.709424

### Trial 5 (already uploaded weight)
mAP: 0.706190

### Summary
Mean: 0.702897
Var:    0.005032


# SegNet  CamVid trained

### Trial 1
```
mean IoU : 0.4581
Class average accuracy : 0.6545
Global average accuracy : 0.7833
```

### Trial 2
```
mean IoU : 0.4386
 Class average accuracy : 0.6422
Global average accuracy : 0.7788
```

### Trial 3
```
mean IoU : 0.5008
Class average accuracy : 0.6724
Global average accuracy : 0.8318
```

### Trial 4
```
mean IoU : 0.4993
Class average accuracy : 0.6564
Global average accuracy : 0.8334
```

### Trial 5
```
mean IoU : 0.4939
Class average accuracy : 0.6705
Global average accuracy : 0.8266
```

### Summary
##### mIoU
mean:   0.4781
std:   0.0252

##### Class average accuracy
mean: 0.6592
std:  0.0111

##### Global average accuracy
mean:  0.8108
std:  0.0244
