### PR TITLE
Remove get_device

### DIFF
--- a/chainercv/links/model/ssd/gradient_scaling.py
+++ b/chainercv/links/model/ssd/gradient_scaling.py
@@ -20,5 +20,5 @@ class GradientScaling(object):
 
     def __call__(self, rule, param):
         g = param.grad
-        with cuda.get_device(g):
+        with cuda.get_device_from_array(g):
             g *= self.rate

--- a/examples/detection/eval_voc07.py
+++ b/examples/detection/eval_voc07.py
@@ -67,7 +67,7 @@ def main():
             model = SSD512(pretrained_model='voc0712')
 
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()
+        chainer.cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()
 
     model.use_preset('evaluate')

--- a/examples/faster_rcnn/demo.py
+++ b/examples/faster_rcnn/demo.py
@@ -23,7 +23,7 @@ def main():
         pretrained_model=args.pretrained_model)
 
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()
+        chainer.cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()
 
     img = utils.read_image(args.image, color=True)

--- a/examples/faster_rcnn/train.py
+++ b/examples/faster_rcnn/train.py
@@ -61,7 +61,7 @@ def main():
     faster_rcnn.use_preset('evaluate')
     model = FasterRCNNTrainChain(faster_rcnn)
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()
+        chainer.cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()
     optimizer = chainer.optimizers.MomentumSGD(lr=args.lr, momentum=0.9)
     optimizer.setup(model)

--- a/examples/segnet/demo.py
+++ b/examples/segnet/demo.py
@@ -25,7 +25,7 @@ def main():
         pretrained_model=args.pretrained_model)
 
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()
+        chainer.cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()
 
     img = utils.read_image(args.image, color=True)

--- a/examples/segnet/eval_camvid.py
+++ b/examples/segnet/eval_camvid.py
@@ -50,7 +50,7 @@ def main():
         n_class=len(camvid_label_names),
         pretrained_model=args.pretrained_model)
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()
+        chainer.cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()
 
     model = calc_bn_statistics(model, args.batchsize)

--- a/examples/segnet/train.py
+++ b/examples/segnet/train.py
@@ -53,7 +53,8 @@ def main():
     model = PixelwiseSoftmaxClassifier(
         model, class_weight=class_weight)
     if args.gpu >= 0:
-        chainer.cuda.get_device_from_id(args.gpu).use()  # Make a specified GPU current
+        # Make a specified GPU current
+        chainer.cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()  # Copy the model to the GPU
 
     # Optimizer

--- a/examples/segnet/train.py
+++ b/examples/segnet/train.py
@@ -53,7 +53,7 @@ def main():
     model = PixelwiseSoftmaxClassifier(
         model, class_weight=class_weight)
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()  # Make a specified GPU current
+        chainer.cuda.get_device_from_id(args.gpu).use()  # Make a specified GPU current
         model.to_gpu()  # Copy the model to the GPU
 
     # Optimizer

--- a/examples/ssd/demo.py
+++ b/examples/ssd/demo.py
@@ -31,7 +31,7 @@ def main():
             pretrained_model=args.pretrained_model)
 
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()
+        chainer.cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()
 
     img = utils.read_image(args.image, color=True)

--- a/examples/ssd/train.py
+++ b/examples/ssd/train.py
@@ -142,7 +142,7 @@ def main():
     model.use_preset('evaluate')
     train_chain = MultiboxTrainChain(model)
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()
+        chainer.cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()
 
     train = TransformDataset(


### PR DESCRIPTION
This PR replaces `chainer.cuda.get_device`, which is deprecated in Chainer v2.