### PR TITLE
standardize tranpose() and resize() tuple format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,5 @@ script:
   - flake8 .
   - autopep8 -r . | tee check_autopep8
   - test ! -s check_autopep8
+  - python style_checker.py .
   - MPLBACKEND="agg" nosetests -a '!gpu,!slow' tests

--- a/chainercv/evaluations/eval_semantic_segmentation.py
+++ b/chainercv/evaluations/eval_semantic_segmentation.py
@@ -58,7 +58,7 @@ def calc_semantic_segmentation_confusion(pred_labels, gt_labels):
         mask = gt_label >= 0
         confusion += np.bincount(
             n_class * gt_label[mask].astype(int) +
-            pred_label[mask], minlength=n_class**2).reshape(n_class, n_class)
+            pred_label[mask], minlength=n_class**2).reshape((n_class, n_class))
 
     for iter_ in (pred_labels, gt_labels):
         # This code assumes any iterator does not contain None as its items.

--- a/chainercv/links/model/faster_rcnn/faster_rcnn.py
+++ b/chainercv/links/model/faster_rcnn/faster_rcnn.py
@@ -225,7 +225,7 @@ class FasterRCNN(chainer.Chain):
         score = list()
         # skip cls_id = 0 because it is the background class
         for l in range(1, self.n_class):
-            cls_bbox_l = raw_cls_bbox.reshape(-1, self.n_class, 4)[:, l, :]
+            cls_bbox_l = raw_cls_bbox.reshape((-1, self.n_class, 4))[:, l, :]
             prob_l = raw_prob[:, l]
             mask = prob_l > self.score_thresh
             cls_bbox_l = cls_bbox_l[mask]
@@ -299,10 +299,11 @@ class FasterRCNN(chainer.Chain):
             std = self.xp.tile(self.xp.asarray(self.loc_normalize_std),
                                self.n_class)
             roi_cls_loc = (roi_cls_loc * std + mean).astype(np.float32)
-            roi_cls_loc = roi_cls_loc.reshape(-1, self.n_class, 4)
+            roi_cls_loc = roi_cls_loc.reshape((-1, self.n_class, 4))
             roi = self.xp.broadcast_to(roi[:, None], roi_cls_loc.shape)
-            cls_bbox = loc2bbox(roi.reshape(-1, 4), roi_cls_loc.reshape(-1, 4))
-            cls_bbox = cls_bbox.reshape(-1, self.n_class * 4)
+            cls_bbox = loc2bbox(roi.reshape((-1, 4)),
+                                roi_cls_loc.reshape((-1, 4)))
+            cls_bbox = cls_bbox.reshape((-1, self.n_class * 4))
             # clip bounding box
             cls_bbox[:, 0::2] = self.xp.clip(cls_bbox[:, 0::2], 0, H / scale)
             cls_bbox[:, 1::2] = self.xp.clip(cls_bbox[:, 1::2], 0, W / scale)

--- a/chainercv/links/model/faster_rcnn/faster_rcnn_train_chain.py
+++ b/chainercv/links/model/faster_rcnn/faster_rcnn_train_chain.py
@@ -131,7 +131,7 @@ class FasterRCNNTrainChain(chainer.Chain):
 
         # Losses for outputs of the head.
         n_sample = roi_cls_loc.shape[0]
-        roi_cls_loc = roi_cls_loc.reshape(n_sample, -1, 4)
+        roi_cls_loc = roi_cls_loc.reshape((n_sample, -1, 4))
         roi_loc = roi_cls_loc[self.xp.arange(n_sample), gt_roi_label]
         roi_loc_loss = _fast_rcnn_loc_loss(
             roi_loc, gt_roi_loc, gt_roi_label, self.roi_sigma)

--- a/chainercv/links/model/faster_rcnn/region_proposal_network.py
+++ b/chainercv/links/model/faster_rcnn/region_proposal_network.py
@@ -113,14 +113,14 @@ class RegionProposalNetwork(chainer.Chain):
         h = F.relu(self.conv1(x))
 
         rpn_locs = self.loc(h)
-        rpn_locs = rpn_locs.transpose((0, 2, 3, 1)).reshape(n, -1, 4)
+        rpn_locs = rpn_locs.transpose((0, 2, 3, 1)).reshape((n, -1, 4))
 
         rpn_scores = self.score(h)
-        rpn_scores = rpn_scores.transpose(0, 2, 3, 1)
+        rpn_scores = rpn_scores.transpose((0, 2, 3, 1))
         rpn_fg_scores =\
-            rpn_scores.reshape(n, hh, ww, n_anchor, 2)[:, :, :, :, 1]
-        rpn_fg_scores = rpn_fg_scores.reshape(n, -1)
-        rpn_scores = rpn_scores.reshape(n, -1, 2)
+            rpn_scores.reshape((n, hh, ww, n_anchor, 2))[:, :, :, :, 1]
+        rpn_fg_scores = rpn_fg_scores.reshape((n, -1))
+        rpn_scores = rpn_scores.reshape((n, -1, 2))
 
         rois = []
         roi_indices = []

--- a/chainercv/links/model/ssd/ssd_vgg16.py
+++ b/chainercv/links/model/ssd/ssd_vgg16.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 # RGB, (C, 1, 1) format
-_imagenet_mean = np.array((123, 117, 104)).reshape(-1, 1, 1)
+_imagenet_mean = np.array((123, 117, 104)).reshape((-1, 1, 1))
 
 
 class VGG16(chainer.Chain):

--- a/chainercv/links/model/ssd/transforms.py
+++ b/chainercv/links/model/ssd/transforms.py
@@ -58,7 +58,7 @@ def random_distort(
     """
     import cv2
 
-    cv_img = img[::-1].transpose(1, 2, 0).astype(np.uint8)
+    cv_img = img[::-1].transpose((1, 2, 0)).astype(np.uint8)
 
     def convert(img, alpha=1, beta=0):
         img = img.astype(float) * alpha + beta
@@ -107,7 +107,7 @@ def random_distort(
         cv_img = hue(cv_img)
         cv_img = contrast(cv_img)
 
-    return cv_img.astype(np.float32).transpose(2, 0, 1)[::-1]
+    return cv_img.astype(np.float32).transpose((2, 0, 1))[::-1]
 
 
 def random_crop_with_bbox_constraints(
@@ -264,7 +264,7 @@ def resize_with_random_interpolation(img, size, return_param=False):
 
     import cv2
 
-    cv_img = img.transpose(1, 2, 0)
+    cv_img = img.transpose((1, 2, 0))
 
     inters = (
         cv2.INTER_LINEAR,
@@ -281,7 +281,7 @@ def resize_with_random_interpolation(img, size, return_param=False):
     if len(cv_img.shape) == 2:
         cv_img = cv_img[:, :, np.newaxis]
 
-    img = cv_img.astype(np.float32).transpose(2, 0, 1)
+    img = cv_img.astype(np.float32).transpose((2, 0, 1))
 
     if return_param:
         return img, {'interpolation': inter}

--- a/chainercv/transforms/image/pca_lighting.py
+++ b/chainercv/transforms/image/pca_lighting.py
@@ -45,6 +45,6 @@ def pca_lighting(img, sigma, eigen_value=None, eigen_vector=None):
     alpha = np.random.normal(0, sigma, size=3)
 
     img = img.copy()
-    img += eigen_vector.dot(eigen_value * alpha).reshape(-1, 1, 1)
+    img += eigen_vector.dot(eigen_value * alpha).reshape((-1, 1, 1))
 
     return img

--- a/chainercv/transforms/image/random_expand.py
+++ b/chainercv/transforms/image/random_expand.py
@@ -64,7 +64,7 @@ def random_expand(img, max_ratio=4, fill=0, return_param=False):
     x_offset = random.randint(0, out_W - W)
 
     out_img = np.empty((C, out_H, out_W), dtype=img.dtype)
-    out_img[:] = np.array(fill).reshape(-1, 1, 1)
+    out_img[:] = np.array(fill).reshape((-1, 1, 1))
     out_img[:, y_offset:y_offset + H, x_offset:x_offset + W] = img
 
     if return_param:

--- a/chainercv/transforms/image/resize.py
+++ b/chainercv/transforms/image/resize.py
@@ -7,7 +7,7 @@ try:
     import cv2
 
     def _resize(img, size, interpolation):
-        img = img.transpose(1, 2, 0)
+        img = img.transpose((1, 2, 0))
         if interpolation == PIL.Image.NEAREST:
             cv_interpolation = cv2.INTER_NEAREST
         elif interpolation == PIL.Image.BILINEAR:
@@ -22,7 +22,7 @@ try:
         # If input is a grayscale image, cv2 returns a two-dimentional array.
         if len(img.shape) == 2:
             img = img[:, :, np.newaxis]
-        return img.transpose(2, 0, 1)
+        return img.transpose((2, 0, 1))
 
 except ImportError:
     def _resize(img, size, interpolation):

--- a/chainercv/transforms/image/resize_contain.py
+++ b/chainercv/transforms/image/resize_contain.py
@@ -55,7 +55,7 @@ def resize_contain(img, size, fill=0, return_param=False):
         img = resize(img, scaled_size)
     y_slice, x_slice = _get_pad_slice(img, size=size)
     out_img = np.empty((C, out_H, out_W), dtype=img.dtype)
-    out_img[:] = np.array(fill).reshape(-1, 1, 1)
+    out_img[:] = np.array(fill).reshape((-1, 1, 1))
     out_img[:, y_slice, x_slice] = img
 
     if return_param:

--- a/chainercv/utils/image.py
+++ b/chainercv/utils/image.py
@@ -37,7 +37,7 @@ def read_image(path, dtype=np.float32, color=True):
         return img[np.newaxis]
     else:
         # transpose (H, W, C) -> (C, H, W)
-        return img.transpose(2, 0, 1)
+        return img.transpose((2, 0, 1))
 
 
 def write_image(img, path):
@@ -55,7 +55,7 @@ def write_image(img, path):
     if img.shape[0] == 1:
         img = img[0]
     else:
-        img = img.transpose(1, 2, 0)
+        img = img.transpose((1, 2, 0))
 
     img = Image.fromarray(img.astype(np.uint8))
     img.save(path)

--- a/chainercv/visualizations/vis_image.py
+++ b/chainercv/visualizations/vis_image.py
@@ -21,6 +21,6 @@ def vis_image(img, ax=None):
         fig = plot.figure()
         ax = fig.add_subplot(1, 1, 1)
     # CHW -> HWC
-    img = img.transpose(1, 2, 0)
+    img = img.transpose((1, 2, 0))
     ax.imshow(img.astype(np.uint8))
     return ax

--- a/style_checker.py
+++ b/style_checker.py
@@ -1,0 +1,85 @@
+import argparse
+import ast
+import os
+import sys
+
+
+def check(source):
+    checkers = (
+        check_reshape,
+        check_transpose,
+    )
+
+    for node in ast.walk(ast.parse(source)):
+        for checker in checkers:
+            for err in checker(node):
+                yield err
+
+
+def check_reshape(node):
+    if not isinstance(node, ast.Call):
+        return
+    if not isinstance(node.func, ast.Attribute):
+        return
+    if isinstance(node.func.value, ast.Name) and \
+       node.func.value.id in {'np', 'cupy', 'F'}:
+        return
+    if not node.func.attr == 'reshape':
+        return
+
+    if len(node.args) > 1:
+        yield (node.lineno, 'reshape(A, B, ...)')
+
+    if len(node.args) == 1 and \
+       isinstance(node.args[0], ast.Tuple) and \
+       len(node.args[0].elts) == 1:
+        yield (node.lineno, 'reshape((A,))')
+
+
+def check_transpose(node):
+    if not isinstance(node, ast.Call):
+        return
+    if not isinstance(node.func, ast.Attribute):
+        return
+    if isinstance(node.func.value, ast.Name) and \
+       node.func.value.id in {'np', 'cupy', 'F'}:
+        return
+    if not node.func.attr == 'transpose':
+        return
+
+    if len(node.args) > 1:
+        yield (node.lineno, 'transpose(A, B, ...)')
+
+    if len(node.args) == 1 and \
+       isinstance(node.args[0], ast.Tuple) and \
+       len(node.args[0].elts) == 1:
+        yield (node.lineno, 'transpose((A,))')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('dir')
+    args = parser.parse_args()
+
+    n_err = 0
+
+    for dir, _, files in os.walk(args.dir):
+        for file in files:
+            _, ext = os.path.splitext(file)
+            if not ext == '.py':
+                continue
+            path = os.path.join(dir, file)
+            lines = open(path).readlines()
+
+            for lineno, msg in check(''.join(lines)):
+                print('{:s}:{:d} : {:s}'.format(path, lineno, msg))
+                print(lines[lineno - 1])
+
+                n_err += 1
+
+    if n_err > 0:
+        sys.exit('{:d} style errors are found.'.format(n_err))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/links_tests/connection_tests/test_conv_2d_activ.py
+++ b/tests/links_tests/connection_tests/test_conv_2d_activ.py
@@ -39,7 +39,7 @@ class TestConv2DActiv(unittest.TestCase):
 
         # Convolution is the identity function.
         initialW = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]],
-                            dtype=np.float32).reshape(1, 1, 3, 3)
+                            dtype=np.float32).reshape((1, 1, 3, 3))
         initial_bias = 0
         if self.args_style == 'explicit':
             self.l = Conv2DActiv(

--- a/tests/links_tests/model_tests/ssd_tests/test_gradient_scaling.py
+++ b/tests/links_tests/model_tests/ssd_tests/test_gradient_scaling.py
@@ -22,8 +22,8 @@ class TestGradientScaling(unittest.TestCase):
 
     def setUp(self):
         self.target = SimpleLink(
-            np.arange(6, dtype=np.float32).reshape(2, 3),
-            np.arange(3, -3, -1, dtype=np.float32).reshape(2, 3))
+            np.arange(6, dtype=np.float32).reshape((2, 3)),
+            np.arange(3, -3, -1, dtype=np.float32).reshape((2, 3)))
 
     def check_gradient_scaling(self):
         w = self.target.param.data

--- a/tests/links_tests/model_tests/ssd_tests/test_ssd.py
+++ b/tests/links_tests/model_tests/ssd_tests/test_ssd.py
@@ -38,7 +38,7 @@ class DummySSD(SSD):
                 aspect_ratios=((2,), (2, 3), (2,))),
             steps=(0.1, 0.25, 1),
             sizes=(0.1, 0.25, 1, 1.2),
-            mean=np.array((0, 1, 2)).reshape(-1, 1, 1))
+            mean=np.array((0, 1, 2)).reshape((-1, 1, 1)))
 
 
 @testing.parameterize(

--- a/tests/utils_tests/image_tests/test_write_image.py
+++ b/tests/utils_tests/image_tests/test_write_image.py
@@ -49,7 +49,7 @@ class TestWriteImage(unittest.TestCase):
                 img = img[np.newaxis]
             else:
                 # transpose (H, W, C) -> (C, H, W)
-                img = img.transpose(2, 0, 1)
+                img = img.transpose((2, 0, 1))
 
             np.testing.assert_equal(img, self.img)
 


### PR DESCRIPTION
related to 389 and 393
merge after 393

## What is changed

- follow `resize` and `transpose` `tuple` style (see https://github.com/chainer/chainercv/pull/389#issuecomment-322169182)