### PR TITLE
Add interpolation options to scale

### DIFF
--- a/chainercv/transforms/image/scale.py
+++ b/chainercv/transforms/image/scale.py
@@ -1,7 +1,9 @@
+import PIL
+
 from chainercv.transforms import resize
 
 
-def scale(img, size, fit_short=True):
+def scale(img, size, fit_short=True, interpolation=PIL.Image.BILINEAR):
     """Rescales the input image to the given "size".
 
     When :obj:`fit_short == True`, the input image will be resized so that
@@ -19,6 +21,10 @@ def scale(img, size, fit_short=True):
         size (int): The length of the smaller edge.
         fit_short (bool): Determines whether to match the length
             of the shorter edge or the longer edge to :obj:`size`.
+        interpolation (int): Determines sampling strategy. This is one of
+            :obj:`PIL.Image.NEAREST`, :obj:`PIL.Image.BILINEAR`,
+            :obj:`PIL.Image.BICUBIC`, :obj:`PIL.Image.LANCZOS`.
+            Bilinear interpolation is the default strategy.
 
     Returns:
         ~numpy.ndarray: A scaled image in CHW format.
@@ -44,4 +50,4 @@ def scale(img, size, fit_short=True):
         else:
             out_size = (size, int(size * W / H))
 
-    return resize(img, out_size)
+    return resize(img, out_size, interpolation)

--- a/tests/transforms_tests/image_tests/test_scale.py
+++ b/tests/transforms_tests/image_tests/test_scale.py
@@ -7,52 +7,66 @@ from chainer import testing
 from chainercv.transforms import scale
 
 
-@testing.parameterize(
-    {'in_shape': (3, 24, 16), 'size': 8,
-     'fit_short': True, 'out_shape': (3, 12, 8)},
-    {'in_shape': (3, 16, 24), 'size': 8,
-     'fit_short': True, 'out_shape': (3, 8, 12)},
-    {'in_shape': (3, 16, 24), 'size': 24,
-     'fit_short': True, 'out_shape': (3, 24, 36)},
-    {'in_shape': (3, 24, 16), 'size': 36,
-     'fit_short': False, 'out_shape': (3, 36, 24)},
-    {'in_shape': (3, 16, 24), 'size': 36,
-     'fit_short': False, 'out_shape': (3, 24, 36)},
-    {'in_shape': (3, 24, 12), 'size': 12,
-     'fit_short': False, 'out_shape': (3, 12, 6)},
-    # grayscale
-    {'in_shape': (1, 16, 24), 'size': 8,
-     'fit_short': True, 'out_shape': (1, 8, 12)},
-    {'in_shape': (1, 16, 24), 'size': 36,
-        'fit_short': False, 'out_shape': (1, 24, 36)},
-    {'interpolation': PIL.Image.NEAREST},
-    {'interpolation': PIL.Image.BILINEAR},
-    {'interpolation': PIL.Image.BICUBIC},
-    {'interpolation': PIL.Image.LANCZOS},
-)
+@testing.parameterize(*testing.product_dict(
+    [
+        {'in_shape': (3, 24, 16), 'size': 8,
+         'fit_short': True, 'out_shape': (3, 12, 8)},
+        {'in_shape': (3, 16, 24), 'size': 8,
+         'fit_short': True, 'out_shape': (3, 8, 12)},
+        {'in_shape': (3, 16, 24), 'size': 24,
+         'fit_short': True, 'out_shape': (3, 24, 36)},
+        {'in_shape': (3, 24, 16), 'size': 36,
+         'fit_short': False, 'out_shape': (3, 36, 24)},
+        {'in_shape': (3, 16, 24), 'size': 36,
+         'fit_short': False, 'out_shape': (3, 24, 36)},
+        {'in_shape': (3, 24, 12), 'size': 12,
+         'fit_short': False, 'out_shape': (3, 12, 6)},
+        # grayscale
+        {'in_shape': (1, 16, 24), 'size': 8,
+         'fit_short': True, 'out_shape': (1, 8, 12)},
+        {'in_shape': (1, 16, 24), 'size': 36,
+         'fit_short': False, 'out_shape': (1, 24, 36)},
+    ],
+    [
+        {'interpolation': PIL.Image.NEAREST},
+        {'interpolation': PIL.Image.BILINEAR},
+        {'interpolation': PIL.Image.BICUBIC},
+        {'interpolation': PIL.Image.LANCZOS},
+    ]
+))
 class TestScale(unittest.TestCase):
 
     def test_scale(self):
         img = np.random.uniform(size=self.in_shape)
 
-        out = scale(img, self.size, fit_short=self.fit_short)
+        out = scale(img, self.size, fit_short=self.fit_short,
+                    interpolation=self.interpolation)
         self.assertEqual(out.shape, self.out_shape)
 
 
-@testing.parameterize(
-    {'in_shape': (3, 24, 16), 'size': 16, 'fit_short': True},
-    {'in_shape': (3, 16, 24), 'size': 16, 'fit_short': True},
-    {'in_shape': (3, 24, 16), 'size': 24, 'fit_short': False},
-    {'in_shape': (3, 16, 24), 'size': 24, 'fit_short': False},
-    # grayscale
-    {'in_shape': (1, 16, 24), 'size': 24, 'fit_short': False},
-)
+@testing.parameterize(*testing.product_dict(
+    [
+        {'in_shape': (3, 24, 16), 'size': 16, 'fit_short': True},
+        {'in_shape': (3, 16, 24), 'size': 16, 'fit_short': True},
+        {'in_shape': (3, 24, 16), 'size': 24, 'fit_short': False},
+        {'in_shape': (3, 16, 24), 'size': 24, 'fit_short': False},
+        # grayscale
+        {'in_shape': (1, 16, 24), 'size': 24, 'fit_short': False},
+    ],
+    [
+        {'interpolation': PIL.Image.NEAREST},
+        {'interpolation': PIL.Image.BILINEAR},
+        {'interpolation': PIL.Image.BICUBIC},
+        {'interpolation': PIL.Image.LANCZOS},
+    ]
+))
 class TestScaleNoResize(unittest.TestCase):
 
     def test_scale_no_resize(self):
         img = np.random.uniform(size=self.in_shape)
 
-        out = scale(img, self.size, fit_short=self.fit_short)
+        out = scale(img, self.size, fit_short=self.fit_short,
+                    interpolation=self.interpolation)
         self.assertIs(img, out)
 
 

--- a/tests/transforms_tests/image_tests/test_scale.py
+++ b/tests/transforms_tests/image_tests/test_scale.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+import PIL
 
 from chainer import testing
 from chainercv.transforms import scale
@@ -23,7 +24,11 @@ from chainercv.transforms import scale
     {'in_shape': (1, 16, 24), 'size': 8,
      'fit_short': True, 'out_shape': (1, 8, 12)},
     {'in_shape': (1, 16, 24), 'size': 36,
-     'fit_short': False, 'out_shape': (1, 24, 36)},
+        'fit_short': False, 'out_shape': (1, 24, 36)},
+    {'interpolation': PIL.Image.NEAREST},
+    {'interpolation': PIL.Image.BILINEAR},
+    {'interpolation': PIL.Image.BICUBIC},
+    {'interpolation': PIL.Image.LANCZOS},
 )
 class TestScale(unittest.TestCase):
 


### PR DESCRIPTION
`transforms/image/resize` can select interpolation options, but `transforms/image/scale` can't.
So I add interpolation options to `scale`.