### PR TITLE
Make a directory for chainercv.utils.image

### DIFF
--- a/chainercv/utils/image/__init__.py
+++ b/chainercv/utils/image/__init__.py
@@ -1,0 +1,2 @@
+from chainercv.utils.image.read_image import read_image  # NOQA
+from chainercv.utils.image.write_image import write_image  # NOQA

--- a/chainercv/utils/image/read_image.py
+++ b/chainercv/utils/image/read_image.py
@@ -38,24 +38,3 @@ def read_image(path, dtype=np.float32, color=True):
     else:
         # transpose (H, W, C) -> (C, H, W)
         return img.transpose((2, 0, 1))
-
-
-def write_image(img, path):
-    """Save an image to a file.
-
-    This function saves an image to given file. The image is in CHW format and
-    the range of its value is :math:`[0, 255]`.
-
-    Args:
-        image (~numpy.ndarray): An image to be saved.
-        path (str): The path of an image file.
-
-    """
-
-    if img.shape[0] == 1:
-        img = img[0]
-    else:
-        img = img.transpose((1, 2, 0))
-
-    img = Image.fromarray(img.astype(np.uint8))
-    img.save(path)

--- a/chainercv/utils/image/write_image.py
+++ b/chainercv/utils/image/write_image.py
@@ -1,0 +1,23 @@
+import numpy as np
+from PIL import Image
+
+
+def write_image(img, path):
+    """Save an image to a file.
+
+    This function saves an image to given file. The image is in CHW format and
+    the range of its value is :math:`[0, 255]`.
+
+    Args:
+        image (~numpy.ndarray): An image to be saved.
+        path (str): The path of an image file.
+
+    """
+
+    if img.shape[0] == 1:
+        img = img[0]
+    else:
+        img = img.transpose((1, 2, 0))
+
+    img = Image.fromarray(img.astype(np.uint8))
+    img.save(path)


### PR DESCRIPTION
In the future, I am planning to add more utility functions for images.
It is better to split those utilities into different files instead of putting all of them in `image.py`.