### PR TITLE
Use old conda version to make travis work again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,17 @@ notifications:
   email: false
 
 install:
+  # We use the older version of conda because there is a bug in version 4.3.27.
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda2-4.3.21-Linux-x86_64.sh -O miniconda.sh;
     else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda3-4.3.21-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
+  # - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
 


### PR DESCRIPTION
Travis is failing due to a bug in anaconda.
https://travis-ci.org/chainer/chainercv/jobs/280709228

This seems to be a known issue. https://github.com/conda/conda/issues/6030
I skimmed through the discussion held there, and this is seemingly likely to be fixed.

> from https://github.com/conda/conda/issues/6030#issuecomment-332631248
"It's a bug in our python packages that things are not falling back to your system gcc. We're going to change the symlinks for miniconda-latest to point to the older release until we have this fixed. Sorry for the headache."

I changed the travis to use older conda without conda updates.