### PR TITLE
Change variable names for Cityscapes to be specific to semantic segmentation

### DIFF
--- a/chainercv/datasets/__init__.py
+++ b/chainercv/datasets/__init__.py
@@ -3,8 +3,8 @@ from chainercv.datasets.camvid.camvid_dataset import camvid_label_colors  # NOQA
 from chainercv.datasets.camvid.camvid_dataset import camvid_label_names  # NOQA
 from chainercv.datasets.camvid.camvid_dataset import CamVidDataset  # NOQA
 from chainercv.datasets.cityscapes.cityscapes_semantic_segmentation_dataset import CityscapesSemanticSegmentationDataset  # NOQA
-from chainercv.datasets.cityscapes.cityscapes_utils import cityscapes_label_colors  # NOQA
-from chainercv.datasets.cityscapes.cityscapes_utils import cityscapes_label_names  # NOQA
+from chainercv.datasets.cityscapes.cityscapes_utils import cityscapes_semantic_segmentation_label_colors  # NOQA
+from chainercv.datasets.cityscapes.cityscapes_utils import cityscapes_semantic_segmentation_label_names  # NOQA
 from chainercv.datasets.cub.cub_keypoint_dataset import CUBKeypointDataset  # NOQA
 from chainercv.datasets.cub.cub_label_dataset import CUBLabelDataset  # NOQA
 from chainercv.datasets.cub.cub_utils import cub_label_names  # NOQA

--- a/chainercv/datasets/cityscapes/cityscapes_utils.py
+++ b/chainercv/datasets/cityscapes/cityscapes_utils.py
@@ -47,8 +47,8 @@ cityscapes_labels = tuple([
     Label('licenseplate', -1, -1, 'vehicle', 7, False, True, (0, 0, 142)),
 ])
 
-cityscapes_label_names = tuple(
+cityscapes_semantic_segmentation_label_names = tuple(
     l.name for l in cityscapes_labels if not l.ignoreInEval)
 
-cityscapes_label_colors = tuple(
+cityscapes_semantic_segmentation_label_colors = tuple(
     l.color for l in cityscapes_labels if not l.ignoreInEval)


### PR DESCRIPTION
https://github.com/chainer/chainercv/pull/429#discussion_r141790417
`cityscapes_label_* --> cityscapes_semantic_segmentation_label_*`

This is not no-compat because Cityscapes has not been included in any release.