### PR TITLE
Fix doc of bbox2loc and loc2bbox

### DIFF
--- a/chainercv/links/model/faster_rcnn/utils/bbox2loc.py
+++ b/chainercv/links/model/faster_rcnn/utils/bbox2loc.py
@@ -27,10 +27,12 @@ def bbox2loc(src_bbox, dst_bbox):
     Args:
         src_bbox (array): An image coordinate array whose shape is
             :math:`(R, 4)`. :math:`R` is the number of bounding boxes.
-            These coordinates are used to compute :math:`p_y, p_x, p_h, p_w`.
+            These coordinates are
+            :math:`p_{ymin}, p_{xmin}, p_{ymax}, p_{xmax}`.
         dst_bbox (array): An image coordinate array whose shape is
             :math:`(R, 4)`.
-            These coordinates are used to compute :math:`g_y, g_x, g_h, g_w`.
+            These coordinates are
+            :math:`g_{ymin}, g_{xmin}, g_{ymax}, g_{xmax}`.
 
     Returns:
         array:

--- a/chainercv/links/model/faster_rcnn/utils/loc2bbox.py
+++ b/chainercv/links/model/faster_rcnn/utils/loc2bbox.py
@@ -29,8 +29,8 @@ def loc2bbox(src_bbox, loc):
 
     Args:
         src_bbox (array): A coordinates of bounding boxes.
-            Its shape is :math:`(R, 4)`. These coordinates are used to
-            compute :math:`p_y, p_x, p_h, p_w`.
+            Its shape is :math:`(R, 4)`. These coordinates are
+            :math:`p_{ymin}, p_{xmin}, p_{ymax}, p_{xmax}`.
         loc (array): An array with offsets and scales.
             The shapes of :obj:`src_bbox` and :obj:`loc` should be same.
             This contains values :math:`t_y, t_x, t_h, t_w`.
@@ -39,7 +39,8 @@ def loc2bbox(src_bbox, loc):
         array:
         Decoded bounding box coordinates. Its shape is :math:`(R, 4)`. \
         The second axis contains four values \
-        :math:`\\hat{g}_y, \\hat{g}_x, \\hat{g}_h, \\hat{g}_w`.
+        :math:`\\hat{g}_{ymin}, \\hat{g}_{xmin},
+        \\hat{g}_{ymax}, \\hat{g}_{xmax}`.
 
     """
     xp = cuda.get_array_module(src_bbox)


### PR DESCRIPTION
+ The description of the returned value of `bbo2loc` was wrong.
+ `These coodrinates are used to compute y, x, h, w` can be misleading. It should be `these coordinates are ymin, xmin, ymax, xmax`.