### PR TITLE
Fix doc of crop_bbox

### DIFF
--- a/chainercv/transforms/bbox/crop_bbox.py
+++ b/chainercv/transforms/bbox/crop_bbox.py
@@ -42,7 +42,7 @@ def crop_bbox(
         contents are listed below with key, value-type and the description
         of the value.
 
-        * **index** (*numpy.ndarray*): An array holding indices of used
+        * **index** (*numpy.ndarray*): An array holding indices of used \
             bounding boxes.
 
     """


### PR DESCRIPTION
What the documentation looked like before this PR.

<img width="598" alt="transforms_ _chainercv_0_7_0_documentation" src="https://user-images.githubusercontent.com/2062128/32105980-3f04b7e0-badf-11e7-9512-1d86f8c1680a.png">
