### PR TITLE
Improve appearence of y_offset and x_offset in doc

### DIFF
--- a/chainercv/transforms/bbox/translate_bbox.py
+++ b/chainercv/transforms/bbox/translate_bbox.py
@@ -4,7 +4,7 @@ def translate_bbox(bbox, y_offset=0, x_offset=0):
     This method is mainly used together with image transforms, such as padding
     and cropping, which translates the left top point of the image from
     coordinate :math:`(0, 0)` to coordinate
-    :math:`(y, x) = (y\_offset, x\_offset)`.
+    :math:`(y, x) = (y_{offset}, x_{offset})`.
 
     The bounding boxes are expected to be packed into a two dimensional
     tensor of shape :math:`(R, 4)`, where :math:`R` is the number of

--- a/chainercv/transforms/keypoint/translate_keypoint.py
+++ b/chainercv/transforms/keypoint/translate_keypoint.py
@@ -3,7 +3,7 @@ def translate_keypoint(keypoint, y_offset=0, x_offset=0):
 
     This method is mainly used together with image transforms, such as padding
     and cropping, which translates the top left point of the image
-    to the coordinate :math:`(y, x) = (y\_offset, x\_offset)`.
+    to the coordinate :math:`(y, x) = (y_{offset}, x_{offset})`.
 
     Args:
         keypoint (~numpy.ndarray): Keypoints in the image.


### PR DESCRIPTION
Before

<img width="716" alt="transforms_ _chainercv_0_7_0_documentation" src="https://user-images.githubusercontent.com/2062128/32106302-1bff038a-bae0-11e7-8080-a048cec52c8a.png">

After

<img width="741" alt="transforms_ _chainercv_0_7_0_documentation" src="https://user-images.githubusercontent.com/2062128/32106366-40fa393e-bae0-11e7-8ceb-4bad8f9dc4ec.png">
