### PR TITLE
fix IOError: image file truncated” with big image

### DIFF
--- a/chainercv/utils/image/read_image.py
+++ b/chainercv/utils/image/read_image.py
@@ -1,5 +1,7 @@
 import numpy as np
 from PIL import Image
+from PIL import ImageFile
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 
 def read_image(path, dtype=np.float32, color=True):


### PR DESCRIPTION
If the image size is too large, then such error will occur: 
`OSError: image file is truncated (13 bytes not processed)`.

The solution I found from stackoverflow: https://stackoverflow.com/questions/12984426/python-pil-ioerror-image-file-truncated-with-big-images.

I tested it and it actually works.