### PR TITLE
calculate loc2bbox as float64 in proposal_creator

### DIFF
--- a/chainercv/links/model/faster_rcnn/utils/proposal_creator.py
+++ b/chainercv/links/model/faster_rcnn/utils/proposal_creator.py
@@ -111,7 +111,8 @@ class ProposalCreator(object):
         anchor = cuda.to_cpu(anchor)
 
         # Convert anchors into proposal via bbox transformations.
-        roi = loc2bbox(anchor, loc)
+        roi = loc2bbox(anchor.astype(np.float64), loc.astype(np.float64))
+        roi = roi.astype(loc.dtype)
 
         # Clip predicted boxes to image.
         roi[:, slice(0, 4, 2)] = np.clip(


### PR DESCRIPTION
in order to avoid `overflow` error in `np.exp`, we can calculate with `np.float64` because it is on CPU.
in `np.float32`, maximum `x` of `np.exp(x)` is around `88`, and it might be exceeded.