### PR TITLE
Allow padding to be different in y and x directions for tile_images

### DIFF
--- a/chainercv/utils/image/tile_images.py
+++ b/chainercv/utils/image/tile_images.py
@@ -10,7 +10,10 @@ def tile_images(imgs, n_col, pad=2, fill=0):
     Args:
         imgs (numpy.ndarray): A batch of images whose shape is BCHW.
         n_col (int): The number of columns in a tile.
-        pad (int): Amount of pad. The default value is 2.
+        pad (int or tuple of two ints): :obj:`pad_y, pad_x`. This is the
+            amounts of padding in y and x directions. If this is an integer,
+            the amounts of padding in the two directions are the same.
+            The default value is 2.
         fill (float, tuple or ~numpy.ndarray): The value of padded pixels.
             If it is :class:`numpy.ndarray`,
             its shape should be :math:`(C, 1, 1)`,
@@ -20,17 +23,21 @@ def tile_images(imgs, n_col, pad=2, fill=0):
         ~numpy.ndarray:
         An image array in CHW format.
         The size of this image is
-        :math:`((H + pad) \\times \\lceil B / n_{n_{col}} \\rceil,
-        (W + pad) \\times n_{col})`.
+        :math:`((H + pad_{y}) \\times \\lceil B / n_{n_{col}} \\rceil,
+        (W + pad_{x}) \\times n_{col})`.
 
     """
+    if isinstance(pad, int):
+        pad = (pad, pad)
+    pad_y, pad_x = pad
+
     B, C, H, W = imgs.shape
     n_col = min(n_col, B)
     n_row = int(math.ceil(B / n_col))
 
     shape = (C,
-             (H + pad) * n_row,
-             (W + pad) * n_col)
+             (H + pad_y) * n_row,
+             (W + pad_x) * n_col)
     tile = np.empty(shape, dtype=imgs.dtype)
     tile[:] = np.array(fill).reshape((-1, 1, 1))
 
@@ -39,8 +46,8 @@ def tile_images(imgs, n_col, pad=2, fill=0):
         for x in range(n_col):
             if k >= B:
                 break
-            start_y = y * (H + pad) + pad // 2
-            start_x = x * (W + pad) + pad // 2
+            start_y = y * (H + pad_y) + pad_y // 2
+            start_x = x * (W + pad_x) + pad_x // 2
             tile[:,
                  start_y: start_y + H,
                  start_x: start_x + W] = imgs[k]

--- a/tests/utils_tests/image_tests/test_tile_images.py
+++ b/tests/utils_tests/image_tests/test_tile_images.py
@@ -10,7 +10,7 @@ from chainercv.utils import tile_images
 
 @testing.parameterize(*testing.product({
     'fill': [128, (104, 117, 123), np.random.uniform(255, size=(3, 1, 1))],
-    'pad': [0, 1, 2, 3]
+    'pad': [0, 1, 2, 3, (3, 5), (5, 2)]
 }))
 class TestTileImages(unittest.TestCase):
 
@@ -23,10 +23,15 @@ class TestTileImages(unittest.TestCase):
         imgs = np.random.uniform(255, size=(B, 3, H, W))
         tile = tile_images(imgs, n_col, self.pad, fill=self.fill)
 
+        if isinstance(self.pad, int):
+            pad_y = self.pad
+            pad_x = self.pad
+        else:
+            pad_y, pad_x = self.pad
         n_row = int(math.ceil(B / n_col))
         self.assertTrue(n_col >= 1 and n_row >= 1)
-        start_y_11 = H + self.pad + self.pad // 2
-        start_x_11 = W + self.pad + self.pad // 2
+        start_y_11 = H + pad_y + pad_y // 2
+        start_x_11 = W + pad_x + pad_x // 2
         tile_11 = tile[:,
                        start_y_11:start_y_11 + H,
                        start_x_11:start_x_11 + W]


### PR DESCRIPTION
This PR changes the `tile_images` to take a tuple for `pad` in addition to an integer.