### PR TITLE
Fix a test failure due to a rounding error

### DIFF
--- a/tests/links_tests/model_tests/ssd_tests/test_random_crop_with_bbox_constraints.py
+++ b/tests/links_tests/model_tests/ssd_tests/test_random_crop_with_bbox_constraints.py
@@ -28,10 +28,11 @@ class TestRandomCropWithBboxConstraints(unittest.TestCase):
             np.testing.assert_equal(
                 out, img[:, param['y_slice'], param['x_slice']])
 
-            self.assertGreaterEqual(out.size, img.size * 0.3 * 0.3)
-            self.assertLessEqual(out.size, img.size * 1 * 1)
-
             # to ignore rounding error, add 1
+            self.assertGreaterEqual(
+                out.shape[0] * (out.shape[1] + 1) * (out.shape[2] + 1),
+                img.size * 0.3 * 0.3)
+            self.assertLessEqual(out.size, img.size * 1 * 1)
             self.assertLessEqual(
                 out.shape[1] / (out.shape[2] + 1),
                 img.shape[1] / img.shape[2] * 2)


### PR DESCRIPTION
The rounding error caused a test to fail (https://github.com/chainer/chainercv/pull/512/commits/8eb8517ed5f604376d51583bb3c1bb1c2401f372).
This PR fixes the problem so that this failure does not occur in the future.