### PR TITLE
vis_keypoint --> vis_point

### DIFF
--- a/chainercv/visualizations/__init__.py
+++ b/chainercv/visualizations/__init__.py
@@ -1,4 +1,4 @@
 from chainercv.visualizations.vis_bbox import vis_bbox  # NOQA
 from chainercv.visualizations.vis_image import vis_image  # NOQA
-from chainercv.visualizations.vis_keypoint import vis_keypoint  # NOQA
+from chainercv.visualizations.vis_point import vis_point  # NOQA
 from chainercv.visualizations.vis_semantic_segmentation import vis_semantic_segmentation  # NOQA

--- a/chainercv/visualizations/vis_point.py
+++ b/chainercv/visualizations/vis_point.py
@@ -4,16 +4,16 @@ import six
 from chainercv.visualizations.vis_image import vis_image
 
 
-def vis_keypoint(img, keypoint, kp_mask=None, ax=None):
-    """Visualize keypoints in an image.
+def vis_point(img, point, mask=None, ax=None):
+    """Visualize points in an image.
 
     Example:
 
         >>> import chainercv
         >>> import matplotlib.pyplot as plot
         >>> dataset = chainercv.datasets.CUBKeypointDataset()
-        >>> img, keypoint, kp_mask = dataset[0]
-        >>> chainercv.visualizations.vis_keypoint(img, keypoint, kp_mask)
+        >>> img, point, mask = dataset[0]
+        >>> chainercv.visualizations.vis_point(img, point, mask)
         >>> plot.show()
 
     Args:
@@ -21,15 +21,15 @@ def vis_keypoint(img, keypoint, kp_mask=None, ax=None):
             This is in RGB format and the range of its value is
             :math:`[0, 255]`. This should be visualizable using
             :obj:`matplotlib.pyplot.imshow(img)`
-        keypoint (~numpy.ndarray): An array with keypoint pairs whose shape is
-            :math:`(K, 2)`, where :math:`K` is
-            the number of keypoints in the array.
+        point (~numpy.ndarray): An array of point coordinates whose shape is
+            :math:`(P, 2)`, where :math:`P` is
+            the number of points.
             The second axis corresponds to :math:`y` and :math:`x` coordinates
-            of the keypoint.
-        kp_mask (~numpy.ndarray, optional): A boolean array whose shape is
-            :math:`(K,)`. If :math:`i` th index is :obj:`True`, the
-            :math:`i` th keypoint is not displayed. If not specified,
-            all keypoints in :obj:`keypoint` will be displayed.
+            of the points.
+        mask (~numpy.ndarray, optional): A boolean array whose shape is
+            :math:`(P,)`. If :math:`i` th index is :obj:`True`, the
+            :math:`i` th point is not displayed. If not specified,
+            all points in :obj:`keypoint` will be displayed.
         ax (matplotlib.axes.Axes, optional): If provided, plot on this axis.
 
     Returns:
@@ -42,18 +42,18 @@ def vis_keypoint(img, keypoint, kp_mask=None, ax=None):
     ax = vis_image(img, ax=ax)
 
     _, H, W = img.shape
-    n_kp = len(keypoint)
+    n_point = len(point)
 
-    if kp_mask is None:
-        kp_mask = np.ones((n_kp,), dtype=np.bool)
+    if mask is None:
+        mask = np.ones((n_point,), dtype=np.bool)
 
     cm = plot.get_cmap('gist_rainbow')
 
-    colors = [cm(1. * i / n_kp) for i in six.moves.range(n_kp)]
+    colors = [cm(1. * i / n_point) for i in six.moves.range(n_point)]
 
-    for i in range(n_kp):
-        if kp_mask[i]:
-            ax.scatter(keypoint[i][1], keypoint[i][0], c=colors[i], s=100)
+    for i in range(n_point):
+        if mask[i]:
+            ax.scatter(point[i][1], point[i][0], c=colors[i], s=100)
 
     ax.set_xlim(left=0, right=W)
     ax.set_ylim(bottom=H - 1, top=0)

--- a/chainercv/visualizations/vis_point.py
+++ b/chainercv/visualizations/vis_point.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 import six
 
@@ -26,7 +28,7 @@ def vis_point(img, point, mask=None, ax=None):
             the number of points.
             The second axis corresponds to :math:`y` and :math:`x` coordinates
             of the points.
-        mask (~numpy.ndarray, optional): A boolean array whose shape is
+        mask (~numpy.ndarray): A boolean array whose shape is
             :math:`(P,)`. If :math:`i` th element is :obj:`True`, the
             :math:`i` th point is not displayed. If not specified,
             all points in :obj:`point` will be displayed.
@@ -49,7 +51,7 @@ def vis_point(img, point, mask=None, ax=None):
 
     cm = plot.get_cmap('gist_rainbow')
 
-    colors = [cm(1. * i / n_point) for i in six.moves.range(n_point)]
+    colors = [cm(i / n_point) for i in six.moves.range(n_point)]
 
     for i in range(n_point):
         if mask[i]:

--- a/chainercv/visualizations/vis_point.py
+++ b/chainercv/visualizations/vis_point.py
@@ -27,7 +27,7 @@ def vis_point(img, point, mask=None, ax=None):
             The second axis corresponds to :math:`y` and :math:`x` coordinates
             of the points.
         mask (~numpy.ndarray, optional): A boolean array whose shape is
-            :math:`(P,)`. If :math:`i` th index is :obj:`True`, the
+            :math:`(P,)`. If :math:`i` th element is :obj:`True`, the
             :math:`i` th point is not displayed. If not specified,
             all points in :obj:`keypoint` will be displayed.
         ax (matplotlib.axes.Axes, optional): If provided, plot on this axis.

--- a/chainercv/visualizations/vis_point.py
+++ b/chainercv/visualizations/vis_point.py
@@ -32,7 +32,7 @@ def vis_point(img, point, mask=None, ax=None):
             :math:`(P,)`. If :math:`i` th element is :obj:`True`, the
             :math:`i` th point is not displayed. If not specified,
             all points in :obj:`point` will be displayed.
-        ax (matplotlib.axes.Axes, optional): If provided, plot on this axis.
+        ax (matplotlib.axes.Axes): If provided, plot on this axis.
 
     Returns:
         ~matploblib.axes.Axes:

--- a/chainercv/visualizations/vis_point.py
+++ b/chainercv/visualizations/vis_point.py
@@ -29,7 +29,7 @@ def vis_point(img, point, mask=None, ax=None):
         mask (~numpy.ndarray, optional): A boolean array whose shape is
             :math:`(P,)`. If :math:`i` th element is :obj:`True`, the
             :math:`i` th point is not displayed. If not specified,
-            all points in :obj:`keypoint` will be displayed.
+            all points in :obj:`point` will be displayed.
         ax (matplotlib.axes.Axes, optional): If provided, plot on this axis.
 
     Returns:

--- a/docs/source/reference/visualizations.rst
+++ b/docs/source/reference/visualizations.rst
@@ -12,9 +12,9 @@ vis_image
 ~~~~~~~~~
 .. autofunction:: vis_image
 
-vis_keypoint
-~~~~~~~~~~~~
-.. autofunction:: vis_keypoint
+vis_point
+~~~~~~~~~
+.. autofunction:: vis_point
 
 vis_semantic_segmentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/visualizations_tests/test_vis_point.py
+++ b/tests/visualizations_tests/test_vis_point.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from chainer import testing
 
-from chainercv.visualizations import vis_keypoint
+from chainercv.visualizations import vis_point
 
 try:
     import matplotlib  # NOQA
@@ -14,17 +14,17 @@ except ImportError:
 
 
 @testing.parameterize(
-    {'kp_mask': np.array([True, True, False])},
-    {'kp_mask': None}
+    {'mask': np.array([True, True, False])},
+    {'mask': None}
 )
-class TestVisKeypoint(unittest.TestCase):
+class TestVisPoint(unittest.TestCase):
 
-    def test_vis_keypoint(self):
+    def test_vis_point(self):
         if optional_modules:
             img = np.random.randint(
                 0, 255, size=(3, 32, 32)).astype(np.float32)
-            keypoint = np.random.uniform(size=(3, 2)).astype(np.float32)
-            ax = vis_keypoint(img, keypoint, self.kp_mask)
+            point = np.random.uniform(size=(3, 2)).astype(np.float32)
+            ax = vis_point(img, point, self.mask)
 
             self.assertTrue(isinstance(ax, matplotlib.axes.Axes))
 


### PR DESCRIPTION
This change is based on the new naming convention (`keypoint, kp_mask --> point, mask`)  https://github.com/chainer/chainercv/issues/507