### PR TITLE
[WIP] SSD residual multibox

### DIFF
--- a/chainercv/links/model/ssd/__init__.py
+++ b/chainercv/links/model/ssd/__init__.py
@@ -1,5 +1,6 @@
 from chainercv.links.model.ssd.gradient_scaling import GradientScaling  # NOQA
 from chainercv.links.model.ssd.multibox import Multibox  # NOQA
+from chainercv.links.model.ssd.multibox import ResidualMultibox  # NOQA
 from chainercv.links.model.ssd.multibox_coder import MultiboxCoder  # NOQA
 from chainercv.links.model.ssd.multibox_loss import multibox_loss  # NOQA
 from chainercv.links.model.ssd.normalize import Normalize  # NOQA

--- a/chainercv/links/model/ssd/multibox.py
+++ b/chainercv/links/model/ssd/multibox.py
@@ -95,3 +95,140 @@ class Multibox(chainer.Chain):
         mb_confs = F.concat(mb_confs, axis=1)
 
         return mb_locs, mb_confs
+
+
+class ResidualMultibox(chainer.Chain):
+    """Multibox head of Deconvolutional Single Shot Detector.
+
+    This is a head part of Deconvolutional Single Shot Detector, also usable
+    as a head part of Single Shot Multibox Detector[#]_.
+
+    This link computes :obj:`mb_locs` and :obj:`mb_confs` from feature maps.
+    :obj:`mb_locs` contains information of the coordinates of bounding boxes
+    and :obj:`mb_confs` contains confidence scores of each classes.
+
+    .. [#] Cheng-Yang Fu, Wei Liu, Ananth Ranga, Ambrish Tyagi,
+       Alexander C. Berg
+       DSSD : Deconvolutional Single Shot Detector.
+       https://arxiv.org/abs/1701.06659.
+
+    Args:
+        n_class (int): The number of classes possibly including the background.
+        aspect_ratios (iterable of tuple or int): The aspect ratios of
+            default bounding boxes for each feature map.
+        initialW: An initializer used in
+            :meth:`chainer.links.Convolution2d.__init__`.
+            The default value is :class:`chainer.initializers.LeCunUniform`.
+        initial_bias: An initializer used in
+            :meth:`chainer.links.Convolution2d.__init__`.
+            The default value is :class:`chainer.initializers.Zero`.
+
+    """
+
+    def __init__(
+            self, n_class, aspect_ratios,
+            initialW=None, initial_bias=None):
+        self.n_class = n_class
+        self.aspect_ratios = aspect_ratios
+
+        super(ResidualMultibox, self).__init__()
+        with self.init_scope():
+            self.res = chainer.ChainList()
+            self.loc = chainer.ChainList()
+            self.conf = chainer.ChainList()
+
+        if initialW is None:
+            initialW = initializers.LeCunUniform()
+        if initial_bias is None:
+            initial_bias = initializers.Zero()
+        init = {'initialW': initialW, 'initial_bias': initial_bias}
+
+        for ar in aspect_ratios:
+            n = (len(ar) + 1) * 2
+            self.res.add_link(Residual(**init))
+            self.loc.add_link(L.Convolution2D(n * 4, 3, pad=1, **init))
+            self.conf.add_link(L.Convolution2D(
+                n * self.n_class, 3, pad=1, **init))
+
+    def __call__(self, xs):
+        """Compute loc and conf from feature maps
+
+        This method computes :obj:`mb_locs` and :obj:`mb_confs`
+        from given feature maps.
+
+        Args:
+            xs (iterable of chainer.Variable): An iterable of feature maps.
+                The number of feature maps must be same as the number of
+                :obj:`aspect_ratios`.
+
+        Returns:
+            tuple of chainer.Variable:
+            This method returns two :obj:`chainer.Variable`: :obj:`mb_locs` and
+            :obj:`mb_confs`.
+
+            * **mb_locs**: A variable of float arrays of shape \
+                :math:`(B, K, 4)`, \
+                where :math:`B` is the number of samples in the batch and \
+                :math:`K` is the number of default bounding boxes.
+            * **mb_confs**: A variable of float arrays of shape \
+                :math:`(B, K, n\_fg\_class + 1)`.
+
+        """
+
+        mb_locs = list()
+        mb_confs = list()
+        for i, x in enumerate(xs):
+            x = self.res[i](x)
+            mb_loc = self.loc[i](x)
+            mb_loc = F.transpose(mb_loc, (0, 2, 3, 1))
+            mb_loc = F.reshape(mb_loc, (mb_loc.shape[0], -1, 4))
+            mb_locs.append(mb_loc)
+
+            mb_conf = self.conf[i](x)
+            mb_conf = F.transpose(mb_conf, (0, 2, 3, 1))
+            mb_conf = F.reshape(
+                mb_conf, (mb_conf.shape[0], -1, self.n_class))
+            mb_confs.append(mb_conf)
+
+        mb_locs = F.concat(mb_locs, axis=1)
+        mb_confs = F.concat(mb_confs, axis=1)
+
+        return mb_locs, mb_confs
+
+
+class Residual(chainer.Chain):
+
+    """A bottleneck layer that reduces the resolution of the feature map.
+    Args:
+        initialW (4-D array): Initial weight value used in
+            the convolutional layers.
+        initial_bias (4-D array): Initial bias value used in
+            the convolutional layers.
+    """
+
+    def __init__(self, initialW=None, initial_bias=None):
+        super(Residual, self).__init__()
+        with self.init_scope():
+            self.conv1 = L.Convolution2D(
+                256, 1, pad=0, initialW=initialW, initial_bias=initial_bias,
+                nobias=True)
+            self.bn1 = L.BatchNormalization(256)
+            self.conv2 = L.Convolution2D(
+                256, 1, pad=0, initialW=initialW, initial_bias=initial_bias,
+                nobias=True)
+            self.bn2 = L.BatchNormalization(256)
+            self.conv3 = L.Convolution2D(
+                1024, 1, pad=0,initialW=initialW, initial_bias=initial_bias,
+                nobias=True)
+            self.bn3 = L.BatchNormalization(1024)
+            self.conv4 = L.Convolution2D(
+                1024, 1, pad=0, initialW=initialW, initial_bias=initial_bias,
+                nobias=True)
+            self.bn4 = L.BatchNormalization(1024)
+
+    def __call__(self, x):
+        h1 = F.relu(self.bn1(self.conv1(x)))
+        h1 = F.relu(self.bn2(self.conv2(h1)))
+        h1 = self.bn3(self.conv3(h1))
+        h2 = self.bn4(self.conv4(x))
+        return F.relu(h1 + h2)

--- a/docs/source/reference/links/ssd.rst
+++ b/docs/source/reference/links/ssd.rst
@@ -38,6 +38,13 @@ Normalize
    :members:
    :special-members:  __call__
 
+ResidualMultibox
+~~~~~~~~~~~~~~~~
+.. autoclass:: ResidualMultibox
+   :members:
+   :special-members:  __call__
+
+
 SSD
 ~~~
 .. autoclass:: SSD


### PR DESCRIPTION
Multibox using residual box is used in ESSD (https://arxiv.org/pdf/1801.05918.pdf) and DSSD (https://arxiv.org/abs/1701.06659).
Only with replacing with Multibox in SSD, mAP can be increased from 76.4% to 77.1%.
I confirmed performance increasing in my local environment.

Anyone interested in supporting this feature?

update:
I found ESSD prediction module is little different (Simply added 1x1x512 layer only).