### PR TITLE
Fix multi-thread hang for cv2

### DIFF
--- a/chainercv/links/model/ssd/transforms.py
+++ b/chainercv/links/model/ssd/transforms.py
@@ -270,6 +270,9 @@ def resize_with_random_interpolation(img, size, return_param=False):
 
     import cv2
 
+    # cv2 sometimes hangs when used in sub-processes, so we set single-thread.
+    cv2.setNumThreads(0)
+
     cv_img = img.transpose((1, 2, 0))
 
     inters = (


### PR DESCRIPTION
`cv2` sometimes hangs when used in sub-processes.
For example `chainercv.links.model.ssd.resize_with_random_interpolation()` does not work with `chainer.iterators.MultiprocessIterator`.

So I set single-thread using `cv2.setNumThreads(0)`.