### PR TITLE
Update interface of vis_instance_segmentation and add color option

### DIFF
--- a/chainercv/utils/__init__.py
+++ b/chainercv/utils/__init__.py
@@ -10,6 +10,7 @@ from chainercv.utils.iterator import apply_to_iterator  # NOQA
 from chainercv.utils.iterator import ProgressHook  # NOQA
 from chainercv.utils.iterator import unzip  # NOQA
 from chainercv.utils.mask.mask_iou import mask_iou  # NOQA
+from chainercv.utils.mask.mask_to_bbox import mask_to_bbox  # NOQA
 from chainercv.utils.testing import assert_is_bbox  # NOQA
 from chainercv.utils.testing import assert_is_bbox_dataset  # NOQA
 from chainercv.utils.testing import assert_is_detection_link  # NOQA

--- a/chainercv/utils/mask/mask_to_bbox.py
+++ b/chainercv/utils/mask/mask_to_bbox.py
@@ -3,20 +3,21 @@ import numpy as np
 
 
 def mask_to_bbox(mask):
-    """Compute the bounding boxes around the masked region.
+    """Compute the bounding boxes around the masked regions.
 
     This function accepts both :obj:`numpy.ndarray` and :obj:`cupy.ndarray` as
     inputs.
 
     Args:
-        mask (array): An array whose shape is :math:`(N, H, W)`.
-            :math:`N` is the number of masks.
+        mask (array): An array whose shape is :math:`(R, H, W)`.
+            :math:`R` is the number of masks.
             The dtype should be :obj:`numpy.bool`.
 
     Returns:
         array:
-        An array whose shape is :math:`(N, 4)`.
-        :math:`N` is the number of bounding boxes.
+        The bounding boxes around the masked regions.
+        This is an array whose shape is :math:`(R, 4)`.
+        :math:`R` is the number of bounding boxes.
         The dtype should be :obj:`numpy.float32`.
 
     """

--- a/chainercv/utils/mask/mask_to_bbox.py
+++ b/chainercv/utils/mask/mask_to_bbox.py
@@ -1,0 +1,43 @@
+from chainer import cuda
+
+
+def mask_to_bbox(mask):
+    """Compute the bounding boxes around the masked region.
+
+    Args:
+        mask (array): An array whose shape is :math:`(N, H, W)`.
+            :math:`N` is the number of masks.
+            The dtype should be :obj:`numpy.bool`.
+
+    Returns:
+        array:
+        An array whose shape is :math:`(N, 4)`.
+        :math:`N` is the number of bounding boxes.
+        The dtype should be :obj:`numpy.float32`.
+
+    """
+    _, H, W = mask.shape
+    xp = cuda.get_array_module(mask)
+
+    valid_y = xp.any(mask, axis=1)
+    y_mins = xp.argmax(mask, axis=1).astype(xp.float32)
+    y_mins[xp.logical_not(valid_y)] = xp.inf
+    y_min = xp.min(y_mins, axis=1)
+
+    valid_x = xp.any(mask, axis=2)
+    x_mins = xp.argmax(mask, axis=2).astype(xp.float32)
+    x_mins[xp.logical_not(valid_x)] = xp.inf
+    x_min = xp.min(x_mins, axis=1)
+
+    flipped_mask = mask[:, ::-1, ::-1]
+
+    valid_y = xp.any(flipped_mask, axis=1)
+    y_maxs = H - xp.argmax(flipped_mask, axis=1).astype(xp.float32)
+    y_maxs[xp.logical_not(valid_y)] = -xp.inf
+    y_max = xp.max(y_maxs, axis=1)
+
+    valid_x = xp.any(flipped_mask, axis=2)
+    x_maxs = W - xp.argmax(flipped_mask, axis=2).astype(xp.float32)
+    x_maxs[xp.logical_not(valid_x)] = -xp.inf
+    x_max = xp.max(x_maxs, axis=1)
+    return xp.stack((y_min, x_min, y_max, x_max), axis=1)

--- a/chainercv/utils/mask/mask_to_bbox.py
+++ b/chainercv/utils/mask/mask_to_bbox.py
@@ -1,5 +1,5 @@
-import numpy as np
 from chainer import cuda
+import numpy as np
 
 
 def mask_to_bbox(mask):

--- a/chainercv/visualizations/colormap.py
+++ b/chainercv/visualizations/colormap.py
@@ -1,0 +1,18 @@
+def voc_colormap(label):
+    """Color map used in PASCAL VOC
+
+    Args:
+        label (int): Class id.
+
+    """
+    r, g, b = 0, 0, 0
+    i = label
+    for j in range(8):
+        if i & (1 << 0):
+            r |= 1 << (7 - j)
+        if i & (1 << 1):
+            g |= 1 << (7 - j)
+        if i & (1 << 2):
+            b |= 1 << (7 - j)
+        i >>= 3
+    return r, g, b

--- a/chainercv/visualizations/vis_image.py
+++ b/chainercv/visualizations/vis_image.py
@@ -7,7 +7,7 @@ def vis_image(img, ax=None):
     Args:
         img (~numpy.ndarray): An array of shape :math:`(3, height, width)`.
             This is in RGB format and the range of its value is
-            :math:`[0, 255]`.
+            :math:`[0, 255]`. If this is :obj:`None`, no image is displayed.
         ax (matplotlib.axes.Axis): The visualization is displayed on this
             axis. If this is :obj:`None` (default), a new axis is created.
 
@@ -20,7 +20,8 @@ def vis_image(img, ax=None):
     if ax is None:
         fig = plot.figure()
         ax = fig.add_subplot(1, 1, 1)
-    # CHW -> HWC
-    img = img.transpose((1, 2, 0))
-    ax.imshow(img.astype(np.uint8))
+    if img is not None:
+        # CHW -> HWC
+        img = img.transpose((1, 2, 0))
+        ax.imshow(img.astype(np.uint8))
     return ax

--- a/chainercv/visualizations/vis_instance_segmentation.py
+++ b/chainercv/visualizations/vis_instance_segmentation.py
@@ -78,15 +78,16 @@ def vis_instance_segmentation(
     colors = np.array(colors)
 
     _, H, W = mask.shape
-    canvas_img = np.zeros((H, W, 3), dtype=np.uint8)
+    canvas_img = np.zeros((H, W, 4), dtype=np.uint8)
     for i, (bb, msk) in enumerate(zip(bbox, mask)):
         # The length of `colors` can be smaller than the number of instances
         # if a non-default `colors` is used.
         color = colors[i % len(colors)]
+        rgba = np.append(color, alpha * 255)
         bb = np.round(bb).astype(np.int32)
         y_min, x_min, y_max, x_max = bb
         if y_max > y_min and x_max > x_min:
-            canvas_img[msk] = color
+            canvas_img[msk] = rgba
 
         caption = []
         if label is not None and label_names is not None:
@@ -104,8 +105,6 @@ def vis_instance_segmentation(
                     style='italic',
                     bbox={'facecolor': color / 255, 'alpha': alpha},
                     fontsize=8, color='white')
- 
-    alpha_img = (alpha * 255 * np.ones((H, W, 1))).astype(np.uint8)
-    canvas_img = np.concatenate((canvas_img, alpha_img), axis=2)
+
     ax.imshow(canvas_img)
     return ax

--- a/chainercv/visualizations/vis_instance_segmentation.py
+++ b/chainercv/visualizations/vis_instance_segmentation.py
@@ -7,7 +7,7 @@ from chainercv.utils.mask.mask_to_bbox import mask_to_bbox
 
 
 def vis_instance_segmentation(
-        img, mask, label=None, score=None, bbox=None, label_names=None,
+        img, mask, label=None, score=None, label_names=None,
         colors=None, alpha=0.7, ax=None):
     """Visualize instance segmentation.
 
@@ -19,9 +19,9 @@ def vis_instance_segmentation(
         >>> from chainercv.visualizations import vis_instance_segmentation
         >>> import matplotlib.pyplot as plot
         >>> dataset = SBDInstanceSegmentationDataset()
-        >>> img, bbox, mask, label = dataset[0]
+        >>> img, mask, label = dataset[0]
         >>> vis_instance_segmentation(
-        ...     img, mask, label, bbox=bbox,
+        ...     img, mask, label,
         ...     label_names=sbd_instance_segmentation_label_names)
         >>> plot.show()
 
@@ -39,12 +39,6 @@ def vis_instance_segmentation(
         score (~numpy.ndarray): A float array of shape :math:`(R,)`.
              Each value indicates how confident the prediction is.
              This is optional.
-        bbox (~numpy.ndarray): A float array of shape :math:`(R, 4)`.
-            :math:`R` is the number of objects in the image, and each
-            vector represents a bounding box of an object.
-            The bounding box is :math:`(y_min, x_min, y_max, x_max)`.
-            This value is optional, and no bounding boxes are displayed
-            if this is not given.
         label_names (iterable of strings): Name of labels ordered according
             to label ids.
         colors: (iterable of tuple): List of colors.
@@ -70,11 +64,7 @@ def vis_instance_segmentation(
         fig = plot.figure()
         ax = fig.add_subplot(1, 1, 1)
 
-    if bbox is None:
-        show_bbox = False
-        bbox = mask_to_bbox(mask)
-    else:
-        show_bbox = True
+    bbox = mask_to_bbox(mask)
 
     if len(bbox) != len(mask):
         raise ValueError('The length of mask must be same as that of bbox')
@@ -97,13 +87,6 @@ def vis_instance_segmentation(
         y_min, x_min, y_max, x_max = bb
         if y_max > y_min and x_max > x_min:
             canvas_img[msk] = alpha * color + canvas_img[msk] * (1 - alpha)
-
-            if show_bbox:
-                ax.add_patch(
-                    plot.Rectangle(
-                        (x_min, y_min), x_max - x_min, y_max - y_min,
-                        fill=False, edgecolor=color / 255, linewidth=0.5,
-                        alpha=alpha))
 
         caption = []
         if label is not None and label_names is not None:

--- a/chainercv/visualizations/vis_instance_segmentation.py
+++ b/chainercv/visualizations/vis_instance_segmentation.py
@@ -3,11 +3,12 @@ from __future__ import division
 import numpy as np
 
 from chainercv.visualizations.colormap import voc_colormap
+from chainercv.utils.mask.mask_to_bbox import mask_to_bbox
 
 
 def vis_instance_segmentation(
-        img, bbox, mask, label=None, score=None, label_names=None,
-        colors=None, alpha=0.7, show_bbox=False, ax=None):
+        img, mask, label=None, score=None, bbox=None, label_names=None,
+        colors=None, alpha=0.7, ax=None):
     """Visualize instance segmentation.
 
     Example:
@@ -20,7 +21,7 @@ def vis_instance_segmentation(
         >>> dataset = SBDInstanceSegmentationDataset()
         >>> img, bbox, mask, label = dataset[0]
         >>> vis_instance_segmentation(
-        ...     img, bbox, mask, label,
+        ...     img, mask, label, bbox=bbox,
         ...     label_names=sbd_instance_segmentation_label_names)
         >>> plot.show()
 
@@ -28,10 +29,6 @@ def vis_instance_segmentation(
         img (~numpy.ndarray): An array of shape :math:`(3, H, W)`.
             This is in RGB format and the range of its value is
             :math:`[0, 255]`.
-        bbox (~numpy.ndarray): A float array of shape :math:`(R, 4)`.
-            :math:`R` is the number of objects in the image, and each
-            vector represents a bounding box of an object.
-            The bounding box is :math:`(y_min, x_min, y_max, x_max)`.
         mask (~numpy.ndarray): A bool array of shape
             :math`(R, H, W)`.
             If there is an object, the value of the pixel is :obj:`True`,
@@ -39,6 +36,15 @@ def vis_instance_segmentation(
         label (~numpy.ndarray): An integer array of shape :math:`(R, )`.
             The values correspond to id for label names stored in
             :obj:`label_names`.
+        score (~numpy.ndarray): A float array of shape :math:`(R,)`.
+             Each value indicates how confident the prediction is.
+             This is optional.
+        bbox (~numpy.ndarray): A float array of shape :math:`(R, 4)`.
+            :math:`R` is the number of objects in the image, and each
+            vector represents a bounding box of an object.
+            The bounding box is :math:`(y_min, x_min, y_max, x_max)`.
+            This value is optional, and no bounding boxes are displayed
+            if this is not given.
         label_names (iterable of strings): Name of labels ordered according
             to label ids.
         colors: (iterable of tuple): List of colors.
@@ -51,8 +57,6 @@ def vis_instance_segmentation(
             value is :obj:`0`, the figure will be completely transparent.
             The default value is :obj:`0.7`. This option is useful for
             overlaying the label on the source image.
-        show_bbox (bool): Decide whether to show bounding boxes.
-            The default value is :obj:`False`.
         ax (matplotlib.axes.Axis): The visualization is displayed on this
             axis. If this is :obj:`None` (default), a new axis is created.
 
@@ -65,6 +69,12 @@ def vis_instance_segmentation(
     if ax is None:
         fig = plot.figure()
         ax = fig.add_subplot(1, 1, 1)
+
+    if bbox is None:
+        show_bbox = False
+        bbox = mask_to_bbox(mask)
+    else:
+        show_bbox = True
 
     if len(bbox) != len(mask):
         raise ValueError('The length of mask must be same as that of bbox')

--- a/chainercv/visualizations/vis_instance_segmentation.py
+++ b/chainercv/visualizations/vis_instance_segmentation.py
@@ -2,8 +2,8 @@ from __future__ import division
 
 import numpy as np
 
-from chainercv.visualizations.colormap import voc_colormap
 from chainercv.utils.mask.mask_to_bbox import mask_to_bbox
+from chainercv.visualizations.colormap import voc_colormap
 
 
 def vis_instance_segmentation(

--- a/chainercv/visualizations/vis_semantic_segmentation.py
+++ b/chainercv/visualizations/vis_semantic_segmentation.py
@@ -2,20 +2,7 @@ from __future__ import division
 
 import numpy as np
 
-
-def _default_cmap(label):
-    """Color map used in PASCAL VOC"""
-    r, g, b = 0, 0, 0
-    i = label
-    for j in range(8):
-        if i & (1 << 0):
-            r |= 1 << (7 - j)
-        if i & (1 << 1):
-            g |= 1 << (7 - j)
-        if i & (1 << 2):
-            b |= 1 << (7 - j)
-        i >>= 3
-    return r, g, b
+from chainercv.visualizations.colormap import voc_colormap
 
 
 def vis_semantic_segmentation(
@@ -56,7 +43,7 @@ def vis_semantic_segmentation(
             labels.
             Each color is RGB format and the range of its values is
             :math:`[0, 255]`.
-            If :obj:`colors` is :obj:`None`, the default color map used.
+            If :obj:`colors` is :obj:`None`, the default color map is used.
         ignore_label_color (tuple): Color for ignored label.
             This is RGB format and the range of its values is :math:`[0, 255]`.
             The default value is :obj:`(0, 0, 0)`.
@@ -104,7 +91,7 @@ def vis_semantic_segmentation(
         label_names = [str(l) for l in range(label.max() + 1)]
 
     if label_colors is None:
-        label_colors = [_default_cmap(l) for l in range(n_class)]
+        label_colors = [voc_colormap(l) for l in range(n_class)]
     # [0, 255] -> [0, 1]
     label_colors = np.array(label_colors) / 255
     cmap = matplotlib.colors.ListedColormap(label_colors)

--- a/docs/source/reference/utils.rst
+++ b/docs/source/reference/utils.rst
@@ -71,6 +71,11 @@ mask_iou
 ~~~~~~~~
 .. autofunction:: mask_iou
 
+mask_to_bbox
+~~~~~~~~~~~~
+.. autofunction:: mask_to_bbox
+
+
 Testing Utilities
 -----------------
 

--- a/tests/utils_tests/mask_tests/test_mask_to_bbox.py
+++ b/tests/utils_tests/mask_tests/test_mask_to_bbox.py
@@ -1,0 +1,50 @@
+from __future__ import division
+
+import unittest
+
+import numpy as np
+
+from chainer import cuda
+from chainer import testing
+from chainer.testing import attr
+
+from chainercv.utils import mask_to_bbox
+
+
+@testing.parameterize(
+    {'mask': np.array(
+        [[[False, False, False, False],
+          [False, True, True, True],
+          [False, True, True, True]
+          ]]),
+     'expected': np.array([[1, 1, 3, 4]], dtype=np.float32)
+    },
+    {'mask': np.array(
+        [[[False, False],
+          [False, True]],
+         [[True, False],
+          [False, True]]]),
+     'expected': np.array([[1, 1, 2, 2], [0, 0, 2, 2]], dtype=np.float32)
+    },
+)
+class TestMaskToBbox(unittest.TestCase):
+
+    def check(self, mask, expected):
+        bbox = mask_to_bbox(mask)
+
+        self.assertIsInstance(bbox, type(expected))
+        np.testing.assert_equal(
+            cuda.to_cpu(bbox),
+            cuda.to_cpu(expected))
+
+    def test_mask_to_bbox(self):
+        self.check(self.mask, self.expected)
+
+    @attr.gpu
+    def test_mask_to_bbox(self):
+        self.check(
+            cuda.to_gpu(self.mask),
+            cuda.to_gpu(self.expected))
+
+
+testing.run_module(__name__, __file__)

--- a/tests/utils_tests/mask_tests/test_mask_to_bbox.py
+++ b/tests/utils_tests/mask_tests/test_mask_to_bbox.py
@@ -18,14 +18,14 @@ from chainercv.utils import mask_to_bbox
           [False, True, True, True]
           ]]),
      'expected': np.array([[1, 1, 3, 4]], dtype=np.float32)
-    },
+     },
     {'mask': np.array(
         [[[False, False],
           [False, True]],
          [[True, False],
           [False, True]]]),
      'expected': np.array([[1, 1, 2, 2], [0, 0, 2, 2]], dtype=np.float32)
-    },
+     },
 )
 class TestMaskToBbox(unittest.TestCase):
 
@@ -37,11 +37,11 @@ class TestMaskToBbox(unittest.TestCase):
             cuda.to_cpu(bbox),
             cuda.to_cpu(expected))
 
-    def test_mask_to_bbox(self):
+    def test_mask_to_bbox_cpu(self):
         self.check(self.mask, self.expected)
 
     @attr.gpu
-    def test_mask_to_bbox(self):
+    def test_mask_to_bbox_gpu(self):
         self.check(
             cuda.to_gpu(self.mask),
             cuda.to_gpu(self.expected))

--- a/tests/visualizations_tests/test_vis_image.py
+++ b/tests/visualizations_tests/test_vis_image.py
@@ -13,13 +13,15 @@ except ImportError:
     optional_modules = False
 
 
+@testing.parameterize(
+    {'img': np.random.randint(0, 255, size=(3, 32, 32)).astype(np.float32)},
+    {'img': None}
+)
 class TestVisImage(unittest.TestCase):
 
     def test_vis_image(self):
         if optional_modules:
-            img = np.random.randint(
-                0, 255, size=(3, 32, 32)).astype(np.float32)
-            ax = vis_image(img)
+            ax = vis_image(self.img)
 
             self.assertTrue(isinstance(ax, matplotlib.axes.Axes))
 

--- a/tests/visualizations_tests/test_vis_instance_segmentation.py
+++ b/tests/visualizations_tests/test_vis_instance_segmentation.py
@@ -47,11 +47,17 @@ except ImportError:
     {
         'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
         'label_names': ('c0', 'c1', 'c2')},
+    {
+        'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
+        'label_names': ('c0', 'c1', 'c2'), 'no_img': False},
 )
 class TestVisInstanceSegmentation(unittest.TestCase):
 
     def setUp(self):
-        self.img = np.random.randint(0, 255, size=(3, 32, 48))
+        if hasattr(self, 'no_img'):
+            self.img = None
+        else:
+            self.img = np.random.randint(0, 255, size=(3, 32, 48))
         self.mask = np.random.randint(
             0, 2, size=(self.n_bbox, 32, 48), dtype=bool)
         if self.label is not None:

--- a/tests/visualizations_tests/test_vis_instance_segmentation.py
+++ b/tests/visualizations_tests/test_vis_instance_segmentation.py
@@ -38,6 +38,13 @@ except ImportError:
     {
         'n_bbox': 0, 'label': (), 'score': (),
         'label_names': ('c0', 'c1', 'c2')},
+    {
+        'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
+        'label_names': ('c0', 'c1', 'c2'),
+        'colors': [(255, 0, 0), (0, 255, 0), (0, 0, 255), (100, 100, 100)]},
+    {
+        'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
+        'label_names': ('c0', 'c1', 'c2'), 'show_bbox': True},
 )
 class TestVisInstanceSegmentation(unittest.TestCase):
 
@@ -51,6 +58,10 @@ class TestVisInstanceSegmentation(unittest.TestCase):
             self.label = np.array(self.label, dtype=np.int32)
         if self.score is not None:
             self.score = np.array(self.score)
+        if not hasattr(self, 'colors'):
+            self.colors = None
+        if not hasattr(self, 'show_bbox'):
+            self.show_bbox = False
 
     def test_vis_instance_segmentation(self):
         if not optional_modules:
@@ -58,7 +69,8 @@ class TestVisInstanceSegmentation(unittest.TestCase):
 
         ax = vis_instance_segmentation(
             self.img, self.bbox, self.mask, self.label, self.score,
-            label_names=self.label_names)
+            label_names=self.label_names, colors=self.colors,
+            show_bbox=self.show_bbox)
 
         self.assertIsInstance(ax, matplotlib.axes.Axes)
 

--- a/tests/visualizations_tests/test_vis_instance_segmentation.py
+++ b/tests/visualizations_tests/test_vis_instance_segmentation.py
@@ -44,33 +44,36 @@ except ImportError:
         'colors': [(255, 0, 0), (0, 255, 0), (0, 0, 255), (100, 100, 100)]},
     {
         'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
+        'label_names': ('c0', 'c1', 'c2')},
+    {
+        'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
         'label_names': ('c0', 'c1', 'c2'), 'show_bbox': True},
 )
 class TestVisInstanceSegmentation(unittest.TestCase):
 
     def setUp(self):
         self.img = np.random.randint(0, 255, size=(3, 32, 48))
-        self.bbox = generate_random_bbox(
-            self.n_bbox, (48, 32), 8, 16)
         self.mask = np.random.randint(
-            0, 1, size=(self.n_bbox, 32, 48), dtype=bool)
+            0, 2, size=(self.n_bbox, 32, 48), dtype=bool)
         if self.label is not None:
             self.label = np.array(self.label, dtype=np.int32)
         if self.score is not None:
             self.score = np.array(self.score)
         if not hasattr(self, 'colors'):
             self.colors = None
-        if not hasattr(self, 'show_bbox'):
-            self.show_bbox = False
+        if hasattr(self, 'show_bbox'):
+            self.bbox = generate_random_bbox(self.n_bbox, (48, 32), 8, 16)
+        else:
+            self.bbox = None
+
 
     def test_vis_instance_segmentation(self):
         if not optional_modules:
             return
 
         ax = vis_instance_segmentation(
-            self.img, self.bbox, self.mask, self.label, self.score,
-            label_names=self.label_names, colors=self.colors,
-            show_bbox=self.show_bbox)
+            self.img, self.mask, self.label, self.score, self.bbox,
+            label_names=self.label_names, colors=self.colors)
 
         self.assertIsInstance(ax, matplotlib.axes.Axes)
 
@@ -89,7 +92,6 @@ class TestVisInstanceSegmentation(unittest.TestCase):
     {
         'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1, 0.75),
         'label_names': ('c0', 'c1', 'c2')},
-
     {
         'n_bbox': 3, 'label': (0, 1, 3), 'score': (0, 0.5, 1),
         'label_names': ('c0', 'c1', 'c2')},
@@ -104,7 +106,7 @@ class TestVisInstanceSegmentationInvalidInputs(unittest.TestCase):
         self.img = np.random.randint(0, 255, size=(3, 32, 48))
         self.bbox = np.random.uniform(size=(self.n_bbox, 4))
         self.mask = np.random.randint(
-            0, 1, size=(self.n_bbox, 32, 48), dtype=bool)
+            0, 2, size=(self.n_bbox, 32, 48), dtype=bool)
         if self.label is not None:
             self.label = np.array(self.label, dtype=int)
         if self.score is not None:
@@ -116,7 +118,7 @@ class TestVisInstanceSegmentationInvalidInputs(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             vis_instance_segmentation(
-                self.img, self.bbox, self.mask, self.label, self.score,
+                self.img, self.mask, self.label, self.score, self.bbox,
                 label_names=self.label_names)
 
 

--- a/tests/visualizations_tests/test_vis_instance_segmentation.py
+++ b/tests/visualizations_tests/test_vis_instance_segmentation.py
@@ -3,7 +3,6 @@ import unittest
 
 from chainer import testing
 
-from chainercv.utils import generate_random_bbox
 from chainercv.visualizations import vis_instance_segmentation
 
 try:
@@ -47,7 +46,7 @@ except ImportError:
         'label_names': ('c0', 'c1', 'c2')},
     {
         'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
-        'label_names': ('c0', 'c1', 'c2'), 'show_bbox': True},
+        'label_names': ('c0', 'c1', 'c2')},
 )
 class TestVisInstanceSegmentation(unittest.TestCase):
 
@@ -61,18 +60,13 @@ class TestVisInstanceSegmentation(unittest.TestCase):
             self.score = np.array(self.score)
         if not hasattr(self, 'colors'):
             self.colors = None
-        if hasattr(self, 'show_bbox'):
-            self.bbox = generate_random_bbox(self.n_bbox, (48, 32), 8, 16)
-        else:
-            self.bbox = None
-
 
     def test_vis_instance_segmentation(self):
         if not optional_modules:
             return
 
         ax = vis_instance_segmentation(
-            self.img, self.mask, self.label, self.score, self.bbox,
+            self.img, self.mask, self.label, self.score,
             label_names=self.label_names, colors=self.colors)
 
         self.assertIsInstance(ax, matplotlib.axes.Axes)
@@ -104,7 +98,6 @@ class TestVisInstanceSegmentationInvalidInputs(unittest.TestCase):
 
     def setUp(self):
         self.img = np.random.randint(0, 255, size=(3, 32, 48))
-        self.bbox = np.random.uniform(size=(self.n_bbox, 4))
         self.mask = np.random.randint(
             0, 2, size=(self.n_bbox, 32, 48), dtype=bool)
         if self.label is not None:
@@ -118,7 +111,7 @@ class TestVisInstanceSegmentationInvalidInputs(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             vis_instance_segmentation(
-                self.img, self.mask, self.label, self.score, self.bbox,
+                self.img, self.mask, self.label, self.score,
                 label_names=self.label_names)
 
 


### PR DESCRIPTION
I changed `vis_instance_segmentation` to support custom `colors`.
This works like `vis_semantic_segmentation`.

Also, I added `show_bbox` option that visualizes bounding box together with masks.
This style of visualization is used by Facebook's detectron.

Finally, I changed `vis_instance_segmentation` from depending on `vis_semantic_segmentation`.