### PR TITLE
Fix ade_label_names and ade_label_colors

### DIFF
--- a/chainercv/datasets/ade20k/ade20k_utils.py
+++ b/chainercv/datasets/ade20k/ade20k_utils.py
@@ -15,6 +15,7 @@ def get_ade20k(root, url):
 
 
 ade20k_semantic_segmentation_label_names = (
+    'other_objects'
     'wall',
     'edifice',
     'sky',
@@ -168,6 +169,7 @@ ade20k_semantic_segmentation_label_names = (
 )
 
 ade20k_semantic_segmentation_label_colors = (
+    (0, 0, 0),
     (120, 120, 120),
     (180, 120, 120),
     (6, 230, 230),

--- a/chainercv/datasets/ade20k/ade20k_utils.py
+++ b/chainercv/datasets/ade20k/ade20k_utils.py
@@ -15,7 +15,7 @@ def get_ade20k(root, url):
 
 
 ade20k_semantic_segmentation_label_names = (
-    'other_objects'
+    'other_objects',
     'wall',
     'edifice',
     'sky',


### PR DESCRIPTION
When `label == 0`, the pixel corresponds to `Other objects` 

https://github.com/CSAILVision/sceneparsing#data
> Note: annotations masks contain labels ranging from 0 to 150, where 0 refers to "other objects". We do not consider those pixels in our evaluation.

Also, the color assigned to this label is `0, 0, 0`.
https://github.com/CSAILVision/sceneparsing/blob/master/visualizationCode/colorEncode.m#L12