### PR TITLE
Make dataset dependent part clear for SegNet example

### DIFF
--- a/examples/segnet/train.py
+++ b/examples/segnet/train.py
@@ -49,7 +49,7 @@ def main():
 
     # Model
     class_weight = np.load(args.class_weight)
-    model = SegNetBasic(n_class=11)
+    model = SegNetBasic(n_class=len(camvid_label_names))
     model = PixelwiseSoftmaxClassifier(
         model, class_weight=class_weight)
     if args.gpu >= 0:


### PR DESCRIPTION
By making hardcoded part clear, it is easier to modify the script to train on different datasets.