### PR TITLE
Make Conv2DActiv support comm kwarg without ChainerMN

### DIFF
--- a/chainercv/links/connection/conv_2d_bn_activ.py
+++ b/chainercv/links/connection/conv_2d_bn_activ.py
@@ -102,6 +102,9 @@ class Conv2DBNActiv(chainer.Chain):
                 self.bn = MultiNodeBatchNormalization(
                     out_channels, **bn_kwargs)
             else:
+                # Remove 'comm' argument if it is included in bn_kwargs
+                bn_kwargs = {key: bn_kwargs[key]
+                             for key in bn_kwargs.keys() if key != 'comm'}
                 self.bn = BatchNormalization(out_channels, **bn_kwargs)
 
     def __call__(self, x):

--- a/tests/links_tests/connection_tests/test_conv_2d_bn_activ.py
+++ b/tests/links_tests/connection_tests/test_conv_2d_bn_activ.py
@@ -26,6 +26,7 @@ except ImportError:
     'dilate': [1, 2],
     'args_style': ['explicit', 'None', 'omit'],
     'activ': ['relu', 'add_one', None],
+    'comm_kwarg': [True, False],
 }))
 class TestConv2DBNActiv(unittest.TestCase):
 
@@ -50,7 +51,10 @@ class TestConv2DBNActiv(unittest.TestCase):
         # Convolution is the identity function.
         initialW = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]],
                             dtype=np.float32).reshape((1, 1, 3, 3))
-        bn_kwargs = {'decay': 0.8}
+        if self.comm_kwarg:
+            bn_kwargs = {'decay': 0.8, 'comm': None}
+        else:
+            bn_kwargs = {'decay': 0.8}
         initial_bias = 0
         if self.args_style == 'explicit':
             self.l = Conv2DBNActiv(

--- a/tests/links_tests/connection_tests/test_conv_2d_bn_activ.py
+++ b/tests/links_tests/connection_tests/test_conv_2d_bn_activ.py
@@ -51,7 +51,7 @@ class TestConv2DBNActiv(unittest.TestCase):
         # Convolution is the identity function.
         initialW = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]],
                             dtype=np.float32).reshape((1, 1, 3, 3))
-        if self.comm_kwarg:
+        if self.comm_kwarg and not _chainermn_available:
             bn_kwargs = {'decay': 0.8, 'comm': None}
         else:
             bn_kwargs = {'decay': 0.8}


### PR DESCRIPTION
An error is raised when `bn_kwargs` includes `comm` when ChainerMN is not installed.