### PR TITLE
fix _check_available in SBDInstanceSegmentationDataset

### DIFF
--- a/chainercv/datasets/sbd/sbd_instance_segmentation_dataset.py
+++ b/chainercv/datasets/sbd/sbd_instance_segmentation_dataset.py
@@ -21,7 +21,7 @@ def _check_available():
             'SciPy is not installed in your environment,',
             'so the dataset cannot be loaded.'
             'Please install SciPy to load dataset.\n\n'
-            '$ pip install scipy')
+            '$ pip install scipy', RuntimeWarning)
 
 
 class SBDInstanceSegmentationDataset(chainer.dataset.DatasetMixin):

--- a/chainercv/datasets/sbd/sbd_instance_segmentation_dataset.py
+++ b/chainercv/datasets/sbd/sbd_instance_segmentation_dataset.py
@@ -18,10 +18,10 @@ except ImportError:
 def _check_available():
     if not _available:
         warnings.warn(
-            'SciPy is not installed in your environment,',
+            'SciPy is not installed in your environment,'
             'so the dataset cannot be loaded.'
             'Please install SciPy to load dataset.\n\n'
-            '$ pip install scipy', RuntimeWarning)
+            '$ pip install scipy')
 
 
 class SBDInstanceSegmentationDataset(chainer.dataset.DatasetMixin):


### PR DESCRIPTION
```
======================================================================
ERROR: test_sbd_instance_segmentation_dataset (test_sbd_instance_segmentation_dataset.transplant_class.<locals>.C)  parameter: {'split': 'train'}
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/chainercv/tests/datasets_tests/sbd_tests/test_sbd_instance_segmentation_dataset.py", line 19, in setUp
    self.dataset = SBDInstanceSegmentationDataset(split=self.split)
  File "/usr/local/lib/python3.5/dist-packages/chainercv-0.8.0-py3.5-linux-x86_64.egg/chainercv/datasets/sbd/sbd_instance_segmentation_dataset.py", line 45, in __init__
    _check_available()
  File "/usr/local/lib/python3.5/dist-packages/chainercv-0.8.0-py3.5-linux-x86_64.egg/chainercv/datasets/sbd/sbd_instance_segmentation_dataset.py", line 22, in _check_available
    'so the dataset cannot be loaded.'
TypeError: category must be a Warning subclass, not 'str'

```