### PR TITLE
Let YOLOv3.predict accept input image other than float32

### DIFF
--- a/chainercv/links/model/yolo/yolo_v3.py
+++ b/chainercv/links/model/yolo/yolo_v3.py
@@ -310,7 +310,7 @@ class YOLOv3(chainer.Chain):
             img, param = transforms.resize_contain(
                 img / 255, (self.insize, self.insize), fill=0.5,
                 return_param=True)
-            x.append(self.xp.array(img))
+            x.append(self.xp.array(img.astype(np.float32)))
             param['size'] = (H, W)
             params.append(param)
 


### PR DESCRIPTION
`predict` method of detector models (e.g. SSD300) can accept images of uint8.
However, `YOLOv3.predict` seems to implicitly assume that input images must be preprocessed as float32.
When uint8 images are input to `YOLOv3.predict`, the images are implicitly converted to float64 by a division and it causes an error.
https://github.com/chainer/chainercv/blob/4efff51cd1e3f800f51433286027b355d9857aa3/chainercv/links/model/yolo/yolo_v3.py#L311

## Code to reproduce
```python
import matplotlib.pyplot as plt
import numpy as np

import chainercv


if __name__ == '__main__':
    image_filenames = ['2009_005279.jpg']

#    net = chainercv.links.model.ssd.SSD300(pretrained_model='voc0712')
    net = chainercv.links.model.yolo.YOLOv3(pretrained_model='voc0712')

    images = []  # HWC-RGB images
    for filename in image_filenames:
        images.append(plt.imread(filename))

    chw_rgbs = []  # input images
    for image in images:
        chw_rgbs.append(image.transpose(2, 0, 1))

    bboxes, labels, scores = net.predict(chw_rgbs)

    for i, (chw_rgb, bbox, label, score) in enumerate(
            zip(chw_rgbs, bboxes, labels, scores)):
        chainercv.visualizations.vis_bbox(
            chw_rgb, bbox, label, score,
            chainercv.datasets.voc_bbox_label_names)
```

## Error
```python
Traceback (most recent call last):

  File "<ipython-input-1-0e12eb74ff8c>", line 1, in <module>
    runfile('C:/Users/sakurai/Google ドライブ/Python/chainer_examples/chainercv_example/untitled1.py', wdir='C:/Users/sakurai/Google ドライブ/Python/chainer_examples/chainercv_example')

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\spyder\utils\site\sitecustomize.py", line 705, in runfile
    execfile(filename, namespace)

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\spyder\utils\site\sitecustomize.py", line 102, in execfile
    exec(compile(f.read(), filename, 'exec'), namespace)

  File "C:/Users/sakurai/Google ドライブ/Python/chainer_examples/chainercv_example/untitled1.py", line 21, in <module>
    bboxes, labels, scores = net.predict(chw_rgbs)

  File "C:\Users\sakurai\Desktop\chainercv\chainercv\links\model\yolo\yolo_v3.py", line 320, in predict
    y = self(self.xp.stack(x)).array

  File "C:\Users\sakurai\Desktop\chainercv\chainercv\links\model\yolo\yolo_v3.py", line 206, in __call__
    for i, h in enumerate(self.extractor(x)):

  File "C:\Users\sakurai\Desktop\chainercv\chainercv\links\model\yolo\yolo_v3.py", line 88, in __call__
    h = link(h)

  File "C:\Users\sakurai\Desktop\chainercv\chainercv\links\connection\conv_2d_bn_activ.py", line 108, in __call__
    h = self.bn(h)

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\chainer\links\normalization\batch_normalization.py", line 159, in __call__
    x, gamma, beta, mean, var, self.eps, axis=self.axis)

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\chainer\functions\normalization\batch_normalization.py", line 825, in fixed_batch_normalization
    var))[0]

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\chainer\function_node.py", line 243, in apply
    self._check_data_type_forward(in_data)

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\chainer\function_node.py", line 328, in _check_data_type_forward
    self.check_type_forward(in_type)

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\chainer\functions\normalization\batch_normalization.py", line 436, in check_type_forward
    var_type.shape == gamma_type.shape,

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\chainer\utils\type_check.py", line 524, in expect
    expr.expect()

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\chainer\utils\type_check.py", line 482, in expect
    '{0} {1} {2}'.format(left, self.inv, right))

InvalidType: 
Invalid operation is performed in: FixedBatchNormalization (Forward)

Expect: in_types[1].dtype == in_types[0].dtype
Actual: float32 != float64
```