### PR TITLE
Fix hacking version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
 script:
   - pwd
   - pip install flake8
-  - pip install hacking
+  - pip install hacking==1.0.0
   - pip install autopep8
   - pip install mock
   - pip install nose


### PR DESCRIPTION
Travis is failing due to the recent change made to `hacking`.
This fix follows Chainer.

https://github.com/chainer/chainer/pull/4731/files