### PR TITLE
Delete unnecessary assignment in ProposalCreator

### DIFF
--- a/chainercv/links/model/faster_rcnn/utils/proposal_creator.py
+++ b/chainercv/links/model/faster_rcnn/utils/proposal_creator.py
@@ -133,7 +133,6 @@ class ProposalCreator(object):
         if n_pre_nms > 0:
             order = order[:n_pre_nms]
         roi = roi[order, :]
-        score = score[order]
 
         # Apply nms (e.g. threshold = 0.7).
         # Take after_nms_topN (e.g. 300).


### PR DESCRIPTION
This PR is to delete unnecessary assignment to score with slicing. 
Since the score is not used after getting its sorted order in line 132.