### PR TITLE
Fix bbox_to_mask to return np.float32

### DIFF
--- a/chainercv/utils/mask/mask_to_bbox.py
+++ b/chainercv/utils/mask/mask_to_bbox.py
@@ -33,4 +33,4 @@ def mask_to_bbox(mask):
         y_min, x_min = where.min(0)
         y_max, x_max = where.max(0) + 1
         bbox.append((y_min, x_min, y_max, x_max))
-    return xp.array(bbox)
+    return xp.array(bbox, dtype=np.float32)

--- a/tests/utils_tests/mask_tests/test_mask_to_bbox.py
+++ b/tests/utils_tests/mask_tests/test_mask_to_bbox.py
@@ -33,6 +33,7 @@ class TestMaskToBbox(unittest.TestCase):
         bbox = mask_to_bbox(mask)
 
         self.assertIsInstance(bbox, type(expected))
+        self.assertEqual(bbox.dtype, expected.dtype)
         np.testing.assert_equal(
             cuda.to_cpu(bbox),
             cuda.to_cpu(expected))


### PR DESCRIPTION
`np.testing.assert_equal` does not check `dtype`!
I did not know that :innocent: 