### PR TITLE
Fix downloading COCO data

### DIFF
--- a/chainercv/datasets/coco/coco_utils.py
+++ b/chainercv/datasets/coco/coco_utils.py
@@ -38,7 +38,7 @@ def get_coco(split, img_split):
         download_file_path = utils.cached_download(anno_url)
         ext = os.path.splitext(anno_url)[1]
         if split in ['train', 'val']:
-            utils.extractall(download_file_path, img_root, ext)
+            utils.extractall(download_file_path, data_dir, ext)
         elif split in ['valminusminival', 'minival']:
             utils.extractall(download_file_path, annos_root, ext)
     return data_dir

--- a/chainercv/datasets/coco/coco_utils.py
+++ b/chainercv/datasets/coco/coco_utils.py
@@ -37,7 +37,10 @@ def get_coco(split, img_split):
         anno_url = anno_urls[split]
         download_file_path = utils.cached_download(anno_url)
         ext = os.path.splitext(anno_url)[1]
-        utils.extractall(download_file_path, annos_root, ext)
+        if split in ['train', 'val']:
+            utils.extractall(download_file_path, img_root, ext)
+        elif split in ['valminusminival', 'minival']:
+            utils.extractall(download_file_path, annos_root, ext)
     return data_dir
 
 


### PR DESCRIPTION
The data in `instances_train-val2014.zip` is organized as `annotations/*`.
With the current code, the annotations are stored in `BASE/annotations/annotations/`.
This PR fixes this problem.