### PR TITLE
Fix VOCFormatBboxDataset

### DIFF
--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+

--- a/chainercv/datasets/__init__.py
+++ b/chainercv/datasets/__init__.py
@@ -27,6 +27,7 @@ from chainercv.datasets.sbd.sbd_utils import sbd_instance_segmentation_label_nam
 from chainercv.datasets.siamese_dataset import SiameseDataset  # NOQA
 from chainercv.datasets.transform_dataset import TransformDataset  # NOQA
 from chainercv.datasets.voc.voc_bbox_dataset import VOCBboxDataset  # NOQA
+from chainercv.datasets.voc.voc_bbox_dataset import VOCFormatBboxDataset  # NOQA
 from chainercv.datasets.voc.voc_instance_segmentation_dataset import VOCInstanceSegmentationDataset  # NOQA
 from chainercv.datasets.voc.voc_semantic_segmentation_dataset import VOCSemanticSegmentationDataset  # NOQA
 from chainercv.datasets.voc.voc_utils import voc_bbox_label_names  # NOQA

--- a/chainercv/datasets/voc/voc_bbox_dataset.py
+++ b/chainercv/datasets/voc/voc_bbox_dataset.py
@@ -29,6 +29,9 @@ class VOCBboxDataset(GetterDataset):
             a boolean array
             that indicates whether bounding boxes are labeled as difficult
             or not. The default value is :obj:`False`.
+        labels (list of string): The label names of classes. If :obj:`None`
+            is specified, :obj:`~chainercv.datasets.voc.voc_utils.voc_bbox_label_names`
+            is assigned. Default is :obj:`None`.
 
     This dataset returns the following data.
 
@@ -51,7 +54,7 @@ class VOCBboxDataset(GetterDataset):
     """
 
     def __init__(self, data_dir='auto', split='train', year='2012',
-                 use_difficult=False, return_difficult=False):
+                 use_difficult=False, return_difficult=False, labels=None):
         super(VOCBboxDataset, self).__init__()
 
         if data_dir == 'auto' and year in ['2007', '2012']:
@@ -77,6 +80,11 @@ class VOCBboxDataset(GetterDataset):
 
         if not return_difficult:
             self.keys = ('img', 'bbox', 'label')
+
+        if labels is None:
+            self.labels = voc_utils.voc_bbox_label_names
+        else:
+            self.labels = labels
 
     def __len__(self):
         return len(self.ids)
@@ -107,7 +115,7 @@ class VOCBboxDataset(GetterDataset):
                 int(bndbox_anno.find(tag).text) - 1
                 for tag in ('ymin', 'xmin', 'ymax', 'xmax')])
             name = obj.find('name').text.lower().strip()
-            label.append(voc_utils.voc_bbox_label_names.index(name))
+            label.append(self.labels.index(name))
         bbox = np.stack(bbox).astype(np.float32)
         label = np.stack(label).astype(np.int32)
         # When `use_difficult==False`, all elements in `difficult` are False.

--- a/chainercv/datasets/voc/voc_bbox_dataset.py
+++ b/chainercv/datasets/voc/voc_bbox_dataset.py
@@ -30,7 +30,8 @@ class VOCBboxDataset(GetterDataset):
             that indicates whether bounding boxes are labeled as difficult
             or not. The default value is :obj:`False`.
         labels (tuple of string): The label names of classes. If :obj:`None`
-            is specified, :obj:`~chainercv.datasets.voc.voc_utils.voc_bbox_label_names`
+            is specified,
+            :obj:`~chainercv.datasets.voc.voc_utils.voc_bbox_label_names`
             is assigned. Default is :obj:`None`.
 
     This dataset returns the following data.
@@ -117,7 +118,10 @@ class VOCBboxDataset(GetterDataset):
                 int(bndbox_anno.find(tag).text) - 1
                 for tag in ('ymin', 'xmin', 'ymax', 'xmax')])
             name = obj.find('name').text.lower().strip()
-            label.append(self.labels.index(name))
+            try:
+                label.append(self.labels.index(name))
+            except Exception as e:
+                print(str(type(e)), e, name)
         bbox = np.stack(bbox).astype(np.float32)
         label = np.stack(label).astype(np.int32)
         # When `use_difficult==False`, all elements in `difficult` are False.

--- a/chainercv/datasets/voc/voc_bbox_dataset.py
+++ b/chainercv/datasets/voc/voc_bbox_dataset.py
@@ -29,7 +29,7 @@ class VOCBboxDataset(GetterDataset):
             a boolean array
             that indicates whether bounding boxes are labeled as difficult
             or not. The default value is :obj:`False`.
-        labels (list of string): The label names of classes. If :obj:`None`
+        labels (tuple of string): The label names of classes. If :obj:`None`
             is specified, :obj:`~chainercv.datasets.voc.voc_utils.voc_bbox_label_names`
             is assigned. Default is :obj:`None`.
 
@@ -84,6 +84,8 @@ class VOCBboxDataset(GetterDataset):
         if labels is None:
             self.labels = voc_utils.voc_bbox_label_names
         else:
+            if type(labels) is not tuple:
+                raise TypeError('\'labels\' argument should be a tuple.')
             self.labels = labels
 
     def __len__(self):

--- a/chainercv/datasets/voc/voc_bbox_dataset.py
+++ b/chainercv/datasets/voc/voc_bbox_dataset.py
@@ -117,10 +117,6 @@ class VOCBboxDataset(GetterDataset):
             a boolean array
             that indicates whether bounding boxes are labeled as difficult
             or not. The default value is :obj:`False`.
-        labels (tuple of string): The label names of classes. If :obj:`None`
-            is specified,
-            :obj:`~chainercv.datasets.voc.voc_utils.voc_bbox_label_names`
-            is assigned. Default is :obj:`None`.
 
     This dataset returns the following data.
 


### PR DESCRIPTION
When trying to use other VOC-format datasets like BCCD (https://github.com/Shenggan/BCCD_Dataset), the fact that labels are fixed to the original VOC's labels causes a problem. This PR added a new dataset class `VOCFormatBboxDatset` for such datasets, which enables to use VOC-format datasets easily.