### PR TITLE
use cupy.RawKernel in non_maximum_suppression

### DIFF
--- a/chainercv/utils/bbox/non_maximum_suppression.py
+++ b/chainercv/utils/bbox/non_maximum_suppression.py
@@ -9,12 +9,6 @@ from chainercv.utils.bbox._nms_gpu_post import _nms_gpu_post
 if cuda.available:
     import cupy as cp
 
-    @cp.util.memoize(for_each_device=True)
-    def _load_kernel(kernel_name, code, options=()):
-        assert isinstance(options, tuple)
-        kernel_code = cp.cuda.compile_with_cache(code, options=options)
-        return kernel_code.get_function(kernel_name)
-
 
 def non_maximum_suppression(bbox, thresh, score=None,
                             limit=None):
@@ -193,7 +187,7 @@ def _call_nms_kernel(bbox, thresh):
 
     mask_dev = cp.zeros((n_bbox * col_blocks,), dtype=np.uint64)
     bbox = cp.ascontiguousarray(bbox, dtype=np.float32)
-    kern = _load_kernel('nms_kernel', _nms_gpu_code)
+    kern = cp.RawKernel(_nms_gpu_code, 'nms_kernel')
     kern(blocks, threads, args=(cp.int32(n_bbox), cp.float32(thresh),
                                 bbox, mask_dev))
 


### PR DESCRIPTION
Fix #679 
use `cupy.RawKernel` in `utils/bbox/non_maximum_suppression.py`
