### PR TITLE
Add interpolation and fill options to rotate

### DIFF
--- a/chainercv/transforms/image/rotate.py
+++ b/chainercv/transforms/image/rotate.py
@@ -1,3 +1,4 @@
+import PIL
 import warnings
 
 
@@ -17,7 +18,7 @@ def _check_available():
             '$ pip install scipy')
 
 
-def rotate(img, angle, expand=True):
+def rotate(img, angle, expand=True, interpolation=PIL.Image.BILINEAR):
     """Rotate images by degrees.
 
     Args:
@@ -27,6 +28,10 @@ def rotate(img, angle, expand=True):
         expand (bool): The output shaped is adapted or not.
             If :obj:`True`, the input image is contained complete in
             the output.
+        interpolation (int): Determines sampling strategy. This is one of
+            :obj:`PIL.Image.NEAREST`, :obj:`PIL.Image.BILINEAR`,
+            :obj:`PIL.Image.BICUBIC`.
+            Bilinear interpolation is the default strategy.
 
     Returns:
         ~numpy.ndarray:
@@ -36,4 +41,14 @@ def rotate(img, angle, expand=True):
 
     _check_available()
 
-    return scipy.ndimage.rotate(img, angle, axes=(2, 1), reshape=expand)
+    # http://scikit-image.org/docs/dev/api/skimage.transform.html#warp
+    if interpolation == PIL.Image.NEAREST:
+        interpolation_order = 0
+    elif interpolation == PIL.Image.BILINEAR:
+        interpolation_order = 1
+    elif interpolation == PIL.Image.BICUBIC:
+        interpolation_order = 3
+
+    return scipy.ndimage.rotate(
+        img, angle, axes=(2, 1), reshape=expand,
+        order=interpolation_order)

--- a/chainercv/transforms/image/rotate.py
+++ b/chainercv/transforms/image/rotate.py
@@ -18,7 +18,7 @@ def _check_available():
             '$ pip install scipy')
 
 
-def rotate(img, angle, expand=True, interpolation=PIL.Image.BILINEAR):
+def rotate(img, angle, expand=True, fill=0, interpolation=PIL.Image.BILINEAR):
     """Rotate images by degrees.
 
     Args:
@@ -28,6 +28,7 @@ def rotate(img, angle, expand=True, interpolation=PIL.Image.BILINEAR):
         expand (bool): The output shaped is adapted or not.
             If :obj:`True`, the input image is contained complete in
             the output.
+        fill (float): The value used for pixels outside the boundaries.
         interpolation (int): Determines sampling strategy. This is one of
             :obj:`PIL.Image.NEAREST`, :obj:`PIL.Image.BILINEAR`,
             :obj:`PIL.Image.BICUBIC`.
@@ -51,4 +52,4 @@ def rotate(img, angle, expand=True, interpolation=PIL.Image.BILINEAR):
 
     return scipy.ndimage.rotate(
         img, angle, axes=(2, 1), reshape=expand,
-        order=interpolation_order)
+        order=interpolation_order, cval=fill)

--- a/tests/transforms_tests/image_tests/test_rotate.py
+++ b/tests/transforms_tests/image_tests/test_rotate.py
@@ -35,7 +35,10 @@ class TestRotate(unittest.TestCase):
             interpolation=self.interpolation)
         expected = flip(expected, x_flip=True)
 
-        np.testing.assert_almost_equal(out, expected, decimal=6)
+        if self.interpolation == PIL.Image.NEAREST:
+            assert np.mean(out == expected) > 0.99
+        else:
+            np.testing.assert_almost_equal(out, expected, decimal=6)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/transforms_tests/image_tests/test_rotate.py
+++ b/tests/transforms_tests/image_tests/test_rotate.py
@@ -1,3 +1,4 @@
+import PIL
 import random
 import unittest
 
@@ -14,6 +15,10 @@ except ImportError:
     _available = False
 
 
+@testing.parameterize(*testing.product({
+    'interpolation': [PIL.Image.NEAREST, PIL.Image.BILINEAR,
+                      PIL.Image.BICUBIC],
+}))
 @unittest.skipUnless(_available, 'SciPy is not installed')
 class TestRotate(unittest.TestCase):
 
@@ -21,9 +26,11 @@ class TestRotate(unittest.TestCase):
         img = np.random.uniform(size=(3, 32, 24))
         angle = random.uniform(-180, 180)
 
-        out = rotate(img, angle)
+        out = rotate(img, angle, interpolation=self.interpolation)
         expected = flip(img, x_flip=True)
-        expected = rotate(expected, -1 * angle)
+        expected = rotate(
+            expected, -1 * angle,
+            interpolation=self.interpolation)
         expected = flip(expected, x_flip=True)
 
         np.testing.assert_almost_equal(out, expected, decimal=6)

--- a/tests/transforms_tests/image_tests/test_rotate.py
+++ b/tests/transforms_tests/image_tests/test_rotate.py
@@ -18,6 +18,7 @@ except ImportError:
 @testing.parameterize(*testing.product({
     'interpolation': [PIL.Image.NEAREST, PIL.Image.BILINEAR,
                       PIL.Image.BICUBIC],
+    'fill': [-1, 0, 100],
 }))
 @unittest.skipUnless(_available, 'SciPy is not installed')
 class TestRotate(unittest.TestCase):
@@ -26,10 +27,11 @@ class TestRotate(unittest.TestCase):
         img = np.random.uniform(size=(3, 32, 24))
         angle = random.uniform(-180, 180)
 
-        out = rotate(img, angle, interpolation=self.interpolation)
+        out = rotate(img, angle, fill=self.fill,
+                     interpolation=self.interpolation)
         expected = flip(img, x_flip=True)
         expected = rotate(
-            expected, -1 * angle,
+            expected, -1 * angle, fill=self.fill,
             interpolation=self.interpolation)
         expected = flip(expected, x_flip=True)
 


### PR DESCRIPTION
The default interpolation was bicubic, but I changed it to bilinear so that it is consistent with `resize`.