### PR TITLE
change range of labels for ADE20K

### DIFF
--- a/chainercv/datasets/ade20k/ade20k_semantic_segmentation_dataset.py
+++ b/chainercv/datasets/ade20k/ade20k_semantic_segmentation_dataset.py
@@ -38,7 +38,7 @@ class ADE20KSemanticSegmentationDataset(GetterDataset):
         :obj:`img`, ":math:`(3, H, W)`", :obj:`float32`, \
         "RGB, :math:`[0, 255]`"
         :obj:`label`, ":math:`(H, W)`", :obj:`int32`, \
-        ":math:`[0, \#class - 1]`"
+        ":math:`[-1, \#class - 1]`"
     """
 
     def __init__(self, data_dir='auto', split='train'):
@@ -72,5 +72,7 @@ class ADE20KSemanticSegmentationDataset(GetterDataset):
         return read_image(self.img_paths[i])
 
     def _get_label(self, i):
-        return read_image(
+        label = read_image(
             self.label_paths[i], dtype=np.int32, color=False)[0]
+        # [-1, n_class - 1]
+        return label - 1

--- a/chainercv/datasets/ade20k/ade20k_utils.py
+++ b/chainercv/datasets/ade20k/ade20k_utils.py
@@ -15,7 +15,6 @@ def get_ade20k(root, url):
 
 
 ade20k_semantic_segmentation_label_names = (
-    'other_objects',
     'wall',
     'edifice',
     'sky',
@@ -169,7 +168,6 @@ ade20k_semantic_segmentation_label_names = (
 )
 
 ade20k_semantic_segmentation_label_colors = (
-    (0, 0, 0),
     (120, 120, 120),
     (180, 120, 120),
     (6, 230, 230),


### PR DESCRIPTION
The `other objects` should be categorized into `ignored label (-1)` as done in other datasets.

ref: https://github.com/CSAILVision/semantic-segmentation-pytorch/blob/master/dataset.py#L149