### PR TITLE
Add `truncated_index' into params of crop_bbox

### DIFF
--- a/tests/transforms_tests/bbox_tests/test_crop_bbox.py
+++ b/tests/transforms_tests/bbox_tests/test_crop_bbox.py
@@ -32,6 +32,7 @@ class TestCropBbox(unittest.TestCase):
             return_param=True)
         np.testing.assert_equal(out, expected)
         np.testing.assert_equal(param['index'], (0, 1, 3, 4))
+        np.testing.assert_equal(param['truncated_index'], (0, 1, 3))
 
     def test_crop_bbox_disallow_outside_center(self):
         expected = np.array((
@@ -45,6 +46,7 @@ class TestCropBbox(unittest.TestCase):
             allow_outside_center=False, return_param=True)
         np.testing.assert_equal(out, expected)
         np.testing.assert_equal(param['index'], (0, 1, 3))
+        np.testing.assert_equal(param['truncated_index'], (0, 1))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Added `truncated_index` parameter for crop_bbox, which indicates which bboxes are truncated by the crop operation.