### PR TITLE
Perform batch size check before converting scales

### DIFF
--- a/chainercv/links/model/faster_rcnn/faster_rcnn_train_chain.py
+++ b/chainercv/links/model/faster_rcnn/faster_rcnn_train_chain.py
@@ -95,11 +95,12 @@ class FasterRCNNTrainChain(chainer.Chain):
             labels = labels.array
         if isinstance(scales, chainer.Variable):
             scales = scales.array
-        scales = cuda.to_cpu(scales)
+
         n = bboxes.shape[0]
         if n != 1:
             raise ValueError('Currently only batch size 1 is supported.')
-
+        scales = cuda.to_cpu(scales)
+        
         _, _, H, W = imgs.shape
         img_size = (H, W)
 


### PR DESCRIPTION
If batch size 2 is used, it fails with
```
scale = np.asscalar(cuda.to_cpu(scale))
  File "...numpy/lib/type_check.py", line 482, in asscalar
    return a.item()
ValueError: can only convert an array of size 1 to a Python scalar
```
Proposed outcome:
By reordering the checks, the `ValueError` would be raised before the conversion, avoiding this error.