### PR TITLE
add sort_by_score option to vis_instance_segmentation

### DIFF
--- a/chainercv/visualizations/vis_instance_segmentation.py
+++ b/chainercv/visualizations/vis_instance_segmentation.py
@@ -9,7 +9,7 @@ from chainercv.visualizations import vis_image
 
 def vis_instance_segmentation(
         img, mask, label=None, score=None, label_names=None,
-        instance_colors=None, alpha=0.7, sort_by_score=False, ax=None):
+        instance_colors=None, alpha=0.7, sort_by_score=True, ax=None):
     """Visualize instance segmentation.
 
     Example:

--- a/chainercv/visualizations/vis_instance_segmentation.py
+++ b/chainercv/visualizations/vis_instance_segmentation.py
@@ -90,6 +90,11 @@ def vis_instance_segmentation(
     # Returns newly instantiated matplotlib.axes.Axes object if ax is None
     ax = vis_image(img, ax=ax)
 
+    if score is not None and len(mask) != len(score):
+        raise ValueError('The length of score must be same as that of mask')
+    if label is not None and len(mask) != len(label):
+        raise ValueError('The length of label must be same as that of mask')
+
     if sort_by_score and score is not None:
         order = np.argsort(score)
         mask = mask[order]
@@ -98,13 +103,6 @@ def vis_instance_segmentation(
             label = label[order]
 
     bbox = mask_to_bbox(mask)
-
-    if len(bbox) != len(mask):
-        raise ValueError('The length of mask must be same as that of bbox')
-    if label is not None and len(bbox) != len(label):
-        raise ValueError('The length of label must be same as that of bbox')
-    if score is not None and len(bbox) != len(score):
-        raise ValueError('The length of score must be same as that of bbox')
 
     n_inst = len(bbox)
     if instance_colors is None:

--- a/chainercv/visualizations/vis_instance_segmentation.py
+++ b/chainercv/visualizations/vis_instance_segmentation.py
@@ -9,7 +9,7 @@ from chainercv.visualizations import vis_image
 
 def vis_instance_segmentation(
         img, mask, label=None, score=None, label_names=None,
-        instance_colors=None, alpha=0.7, ax=None):
+        instance_colors=None, alpha=0.7, sort_by_score=False, ax=None):
     """Visualize instance segmentation.
 
     Example:
@@ -77,6 +77,8 @@ def vis_instance_segmentation(
             value is :obj:`0`, the figure will be completely transparent.
             The default value is :obj:`0.7`. This option is useful for
             overlaying the label on the source image.
+        sort_by_score (bool): When :obj:`True`, instances with high scores
+            are always visualized in front of instances with low scores.
         ax (matplotlib.axes.Axis): The visualization is displayed on this
             axis. If this is :obj:`None` (default), a new axis is created.
 
@@ -87,6 +89,13 @@ def vis_instance_segmentation(
     """
     # Returns newly instantiated matplotlib.axes.Axes object if ax is None
     ax = vis_image(img, ax=ax)
+
+    if sort_by_score and score is not None:
+        order = np.argsort(score)
+        mask = mask[order]
+        score = score[order]
+        if label is not None:
+            label = label[order]
 
     bbox = mask_to_bbox(mask)
 

--- a/tests/visualizations_tests/test_vis_instance_segmentation.py
+++ b/tests/visualizations_tests/test_vis_instance_segmentation.py
@@ -13,45 +13,46 @@ except ImportError:
 
 
 @testing.parameterize(
-    {
-        'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
-        'label_names': ('c0', 'c1', 'c2')},
-    {
-        'n_bbox': 3, 'label': (0, 1, 2), 'score': None,
-        'label_names': ('c0', 'c1', 'c2')},
-    {
-        'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
-        'label_names': None},
-    {
-        'n_bbox': 3, 'label': None, 'score': (0, 0.5, 1),
-        'label_names': ('c0', 'c1', 'c2')},
-    {
-        'n_bbox': 3, 'label': None, 'score': (0, 0.5, 1),
-        'label_names': None},
-    {
-        'n_bbox': 3, 'label': None, 'score': None,
-        'label_names': None},
-    {
-        'n_bbox': 3, 'label': (0, 1, 1), 'score': (0, 0.5, 1),
-        'label_names': ('c0', 'c1', 'c2')},
-    {
-        'n_bbox': 0, 'label': (), 'score': (),
-        'label_names': ('c0', 'c1', 'c2')},
-    {
-        'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
-        'label_names': ('c0', 'c1', 'c2'),
-        'instance_colors': [
-            (255, 0, 0), (0, 255, 0), (0, 0, 255), (100, 100, 100)]},
-    {
-        'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
-        'label_names': ('c0', 'c1', 'c2')},
-    {
-        'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
-        'label_names': ('c0', 'c1', 'c2')},
-    {
-        'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
-        'label_names': ('c0', 'c1', 'c2'), 'no_img': False},
-)
+    *testing.product_dict([
+        {
+            'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
+            'label_names': ('c0', 'c1', 'c2')},
+        {
+            'n_bbox': 3, 'label': (0, 1, 2), 'score': None,
+            'label_names': ('c0', 'c1', 'c2')},
+        {
+            'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
+            'label_names': None},
+        {
+            'n_bbox': 3, 'label': None, 'score': (0, 0.5, 1),
+            'label_names': ('c0', 'c1', 'c2')},
+        {
+            'n_bbox': 3, 'label': None, 'score': (0, 0.5, 1),
+            'label_names': None},
+        {
+            'n_bbox': 3, 'label': None, 'score': None,
+            'label_names': None},
+        {
+            'n_bbox': 3, 'label': (0, 1, 1), 'score': (0, 0.5, 1),
+            'label_names': ('c0', 'c1', 'c2')},
+        {
+            'n_bbox': 0, 'label': (), 'score': (),
+            'label_names': ('c0', 'c1', 'c2')},
+        {
+            'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
+            'label_names': ('c0', 'c1', 'c2'),
+            'instance_colors': [
+                (255, 0, 0), (0, 255, 0), (0, 0, 255), (100, 100, 100)]},
+        {
+            'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
+            'label_names': ('c0', 'c1', 'c2')},
+        {
+            'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
+            'label_names': ('c0', 'c1', 'c2')},
+        {
+            'n_bbox': 3, 'label': (0, 1, 2), 'score': (0, 0.5, 1),
+            'label_names': ('c0', 'c1', 'c2'), 'no_img': False},
+    ], [{'sort_by_score': False}, {'sort_by_score': True}]))
 @unittest.skipUnless(_available, 'Matplotlib is not installed')
 class TestVisInstanceSegmentation(unittest.TestCase):
 
@@ -78,7 +79,7 @@ class TestVisInstanceSegmentation(unittest.TestCase):
         self.assertIsInstance(ax, matplotlib.axes.Axes)
 
 
-@testing.parameterize(
+@testing.parameterize(*testing.product_dict([
     {
         'n_bbox': 3, 'label': (0, 1), 'score': (0, 0.5, 1),
         'label_names': ('c0', 'c1', 'c2')},
@@ -98,8 +99,7 @@ class TestVisInstanceSegmentation(unittest.TestCase):
     {
         'n_bbox': 3, 'label': (-1, 1, 2), 'score': (0, 0.5, 1),
         'label_names': ('c0', 'c1', 'c2')},
-
-)
+], [{'sort_by_score': False}, {'sort_by_score': True}]))
 @unittest.skipUnless(_available, 'Matplotlib is not installed')
 class TestVisInstanceSegmentationInvalidInputs(unittest.TestCase):
 

--- a/tests/visualizations_tests/test_vis_instance_segmentation.py
+++ b/tests/visualizations_tests/test_vis_instance_segmentation.py
@@ -74,7 +74,8 @@ class TestVisInstanceSegmentation(unittest.TestCase):
         ax = vis_instance_segmentation(
             self.img, self.mask, self.label, self.score,
             label_names=self.label_names,
-            instance_colors=self.instance_colors)
+            instance_colors=self.instance_colors,
+            sort_by_score=self.sort_by_score)
 
         self.assertIsInstance(ax, matplotlib.axes.Axes)
 
@@ -116,7 +117,7 @@ class TestVisInstanceSegmentationInvalidInputs(unittest.TestCase):
         with self.assertRaises(ValueError):
             vis_instance_segmentation(
                 self.img, self.mask, self.label, self.score,
-                label_names=self.label_names)
+                label_names=self.label_names, sort_by_score=self.sort_by_score)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
It is usually more informative to visualize a highly scored instance in front of less scored ones.
Here is an example (yellow instance in the right corner of the left image is with very low score. Ideally, this should not hide the more highly scored "car" instance, which is in orange).
The left image is with `sort_by_score=False` and the right image is with `sort_by_score=True`.

![figure_1-5](https://user-images.githubusercontent.com/2062128/52606388-bd377f80-2eb5-11e9-874f-ff15319836c1.png)
