### PR TITLE
Prevent mutating input of FeaturePredictor.prepare

### DIFF
--- a/chainercv/links/model/feature_predictor.py
+++ b/chainercv/links/model/feature_predictor.py
@@ -103,6 +103,8 @@ class FeaturePredictor(chainer.Chain):
                 img = scale(img, size=self.scale_size)
             else:
                 img = resize(img, size=self.scale_size)
+        else:
+            img = img.copy()
 
         if self.crop == '10':
             imgs = ten_crop(img, self.crop_size)

--- a/tests/links_tests/model_tests/test_feature_predictor.py
+++ b/tests/links_tests/model_tests/test_feature_predictor.py
@@ -105,6 +105,12 @@ class TestFeaturePredictor(unittest.TestCase):
 
         self.assertEqual(out.shape, self.expected_shape)
 
+    def test_prepare_original_unaffected(self):
+        original = np.random.uniform(size=(self.in_channels, 286, 286))
+        input_ = original.copy()
+        self.link._prepare(input_)
+        np.testing.assert_equal(original, input_)
+
     def test_mean(self):
         if self.mean is None:
             np.testing.assert_equal(self.link.mean, self.link.extractor.mean)


### PR DESCRIPTION
When `scale_size` is `None`, a bug occurs.