### PR TITLE
Add chainermn support to apply_to_iterator

### DIFF
--- a/chainercv/utils/iterator/apply_to_iterator.py
+++ b/chainercv/utils/iterator/apply_to_iterator.py
@@ -85,8 +85,7 @@ def apply_to_iterator(func, iterator, n_input=1, hook=None, comm=None):
             Note that these values do not contain data from the previous
             iterations.
             If :obj:`comm` is specified, only the root worker executes
-            this hook. In that case, the arguments of the hook will be values
-            of all worksers.
+            this hook.
         comm (~chainermn.communicators.CommunicatorBase):
             A ChainerMN communicator.
             If it is specified, this function scatters the iterator of

--- a/chainercv/utils/iterator/apply_to_iterator.py
+++ b/chainercv/utils/iterator/apply_to_iterator.py
@@ -206,12 +206,12 @@ def _apply(func, iterator, n_input, hook, comm):
                 # out_values_local: [out_val] -> ([out_val],)
                 out_values_local = out_values_local,
 
-        if comm_rank == 0:
-            if comm is None:
-                out_values_locals = [out_values_local]
-            else:
-                out_values_locals = comm.gather_obj(out_values_local)
+        if comm is None:
+            out_values_locals = [out_values_local]
+        else:
+            out_values_locals = comm.gather_obj(out_values_local)
 
+        if comm_rank == 0:
             out_values = out_values_locals.pop(0)
             for out_values_local in out_values_locals:
                 if out_values_local is None:
@@ -232,8 +232,6 @@ def _apply(func, iterator, n_input, hook, comm):
                 hook(in_values, out_values, rest_values)
 
             yield in_values, out_values, rest_values
-        else:
-            comm.gather_obj(out_values_local)
 
 
 def _flatten(iterator):

--- a/chainercv/utils/iterator/apply_to_iterator.py
+++ b/chainercv/utils/iterator/apply_to_iterator.py
@@ -164,15 +164,16 @@ def _apply(func, iterator, n_input, hook, comm):
                 q = len(batch) // comm_size
                 r = len(batch) % comm_size
 
-                if not batchsize_checked and not r == 0:
-                    warnings.warn(
-                        'The batchsize of the given iterator ({}) is not '
-                        'a multiple of the number of workers ({}). '
-                        'The total batchsize among all workers should be '
-                        'specified and current setting will have a bad '
-                        'effect on performace. '
-                        .format(len(batch), comm_size),
-                        RuntimeWarning)
+                if not batchsize_checked:
+                    if not r == 0:
+                        warnings.warn(
+                            'The batchsize of the given iterator ({}) is not '
+                            'a multiple of the number of workers ({}). '
+                            'The total batchsize among all workers should be '
+                            'specified and current setting will have a bad '
+                            'effect on performace. '
+                            .format(len(batch), comm_size),
+                            RuntimeWarning)
                     batchsize_checked = True
 
                 in_values = []

--- a/examples/detection/eval_coco_multi.py
+++ b/examples/detection/eval_coco_multi.py
@@ -1,5 +1,4 @@
 import argparse
-import multiprocessing
 
 import chainer
 from chainer import iterators
@@ -24,13 +23,6 @@ def main():
     parser.add_argument('--pretrained-model')
     parser.add_argument('--batchsize', type=int, default=1)
     args = parser.parse_args()
-
-    # https://docs.chainer.org/en/stable/chainermn/tutorial/tips_faqs.html#using-multiprocessiterator
-    if hasattr(multiprocessing, 'set_start_method'):
-        multiprocessing.set_start_method('forkserver')
-        p = multiprocessing.Process()
-        p.start()
-        p.join()
 
     if args.model == 'faster_rcnn_fpn_resnet50':
         if args.pretrained_model:

--- a/examples/detection/eval_coco_multi.py
+++ b/examples/detection/eval_coco_multi.py
@@ -1,0 +1,90 @@
+import argparse
+import multiprocessing
+
+import chainer
+from chainer import iterators
+
+import chainermn
+
+from chainercv.datasets import coco_bbox_label_names
+from chainercv.datasets import COCOBboxDataset
+from chainercv.evaluations import eval_detection_coco
+from chainercv.links import FasterRCNNFPNResNet101
+from chainercv.links import FasterRCNNFPNResNet50
+from chainercv.utils import apply_to_iterator
+from chainercv.utils import ProgressHook
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--model',
+        choices=('faster_rcnn_fpn_resnet50', 'faster_rcnn_fpn_resnet101'),
+        default='faster_rcnn_fpn_resnet50')
+    parser.add_argument('--pretrained-model')
+    parser.add_argument('--batchsize', type=int, default=1)
+    args = parser.parse_args()
+
+    # https://docs.chainer.org/en/stable/chainermn/tutorial/tips_faqs.html#using-multiprocessiterator
+    if hasattr(multiprocessing, 'set_start_method'):
+        multiprocessing.set_start_method('forkserver')
+        p = multiprocessing.Process()
+        p.start()
+        p.join()
+
+    if args.model == 'faster_rcnn_fpn_resnet50':
+        if args.pretrained_model:
+            model = FasterRCNNFPNResNet50(
+                n_fg_class=len(coco_bbox_label_names),
+                pretrained_model=args.pretrained_model)
+        else:
+            model = FasterRCNNFPNResNet50(pretrained_model='coco')
+    elif args.model == 'faster_rcnn_fpn_resnet101':
+        if args.pretrained_model:
+            model = FasterRCNNFPNResNet101(
+                n_fg_class=len(coco_bbox_label_names),
+                pretrained_model=args.pretrained_model)
+        else:
+            model = FasterRCNNFPNResNet101(pretrained_model='coco')
+
+    comm = chainermn.create_communicator()
+    device = comm.intra_rank
+
+    chainer.cuda.get_device_from_id(device).use()
+    model.to_gpu()
+
+    model.use_preset('evaluate')
+
+    if not comm.rank == 0:
+        apply_to_iterator(model.predict, None, comm=comm)
+        return
+
+    dataset = COCOBboxDataset(
+        year='2017',
+        split='val',
+        use_crowded=True,
+        return_area=True,
+        return_crowded=True)
+    iterator = iterators.MultithreadIterator(
+        dataset, args.batchsize, repeat=False, shuffle=False)
+
+    in_values, out_values, rest_values = apply_to_iterator(
+        model.predict, iterator, hook=ProgressHook(len(dataset)), comm=comm)
+    # delete unused iterators explicitly
+    del in_values
+
+    pred_bboxes, pred_labels, pred_scores = out_values
+    gt_bboxes, gt_labels, gt_area, gt_crowded = rest_values
+
+    result = eval_detection_coco(
+        pred_bboxes, pred_labels, pred_scores,
+        gt_bboxes, gt_labels, gt_area, gt_crowded)
+
+    print()
+    for area in ('all', 'large', 'medium', 'small'):
+        print('mmAP ({}):'.format(area),
+              result['map/iou=0.50:0.95/area={}/max_dets=100'.format(area)])
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/detection/eval_coco_multi.py
+++ b/examples/detection/eval_coco_multi.py
@@ -66,7 +66,7 @@ def main():
         return_area=True,
         return_crowded=True)
     iterator = iterators.MultithreadIterator(
-        dataset, args.batchsize, repeat=False, shuffle=False)
+        dataset, args.batchsize * comm.size, repeat=False, shuffle=False)
 
     in_values, out_values, rest_values = apply_to_iterator(
         model.predict, iterator, hook=ProgressHook(len(dataset)), comm=comm)

--- a/examples/semantic_segmentation/eval_semantic_segmentation_multi.py
+++ b/examples/semantic_segmentation/eval_semantic_segmentation_multi.py
@@ -1,16 +1,11 @@
-from __future__ import division
-
 import argparse
-import multiprocessing
-import numpy as np
 
 import chainer
 from chainer import iterators
 
 import chainermn
 
-from chainercv.evaluations import calc_semantic_segmentation_confusion
-from chainercv.evaluations import calc_semantic_segmentation_iou
+from chainercv.evaluations import eval_semantic_segmentation
 from chainercv.utils import apply_to_iterator
 from chainercv.utils import ProgressHook
 
@@ -28,13 +23,6 @@ def main():
     parser.add_argument('--input-size', type=int, default=None)
     args = parser.parse_args()
 
-    # https://docs.chainer.org/en/stable/chainermn/tutorial/tips_faqs.html#using-multiprocessiterator
-    if hasattr(multiprocessing, 'set_start_method'):
-        multiprocessing.set_start_method('forkserver')
-        p = multiprocessing.Process()
-        p.start()
-        p.join()
-
     comm = chainermn.create_communicator()
     device = comm.intra_rank
 
@@ -46,46 +34,34 @@ def main():
     dataset, label_names, model = get_dataset_and_model(
         args.dataset, args.model, args.pretrained_model,
         input_size)
-    assert len(dataset) % comm.size == 0, \
-        "The size of the dataset should be a multiple "\
-        "of the number of GPUs"
 
     chainer.cuda.get_device_from_id(device).use()
     model.to_gpu()
 
-    if comm.rank == 0:
-        indices = np.arange(len(dataset))
-    else:
-        indices = None
-    indices = chainermn.scatter_dataset(indices, comm)
-    dataset = dataset.slice[indices]
+    if not comm.rank == 0:
+        apply_to_iterator(model.predict, None, comm=comm)
+        return
 
-    it = iterators.SerialIterator(
+    it = iterators.MultithreadIterator(
         dataset, 1, repeat=False, shuffle=False)
 
     in_values, out_values, rest_values = apply_to_iterator(
-        model.predict, it, hook=ProgressHook(len(dataset)))
+        model.predict, it, hook=ProgressHook(len(dataset)), comm=comm)
     # Delete an iterator of images to save memory usage.
     del in_values
     pred_labels, = out_values
     gt_labels, = rest_values
 
-    confusion = calc_semantic_segmentation_confusion(pred_labels, gt_labels)
-    confusion = comm.allreduce(confusion)
+    result = eval_semantic_segmentation(pred_labels, gt_labels)
 
-    if comm.rank == 0:
-        iou = calc_semantic_segmentation_iou(confusion)
-        pixel_accuracy = np.diag(confusion).sum() / confusion.sum()
-        class_accuracy = np.diag(confusion) / np.sum(confusion, axis=1)
-
-        for iu, label_name in zip(iou, label_names):
-            print('{:>23} : {:.4f}'.format(label_name, iu))
-        print('=' * 34)
-        print('{:>23} : {:.4f}'.format('mean IoU', np.nanmean(iou)))
-        print('{:>23} : {:.4f}'.format(
-            'Class average accuracy', np.nanmean(class_accuracy)))
-        print('{:>23} : {:.4f}'.format(
-            'Global average accuracy', pixel_accuracy))
+    for iu, label_name in zip(result['iou'], label_names):
+        print('{:>23} : {:.4f}'.format(label_name, iu))
+    print('=' * 34)
+    print('{:>23} : {:.4f}'.format('mean IoU', result['miou']))
+    print('{:>23} : {:.4f}'.format(
+        'Class average accuracy', result['mean_class_accuracy']))
+    print('{:>23} : {:.4f}'.format(
+        'Global average accuracy', result['pixel_accuracy']))
 
 
 if __name__ == '__main__':

--- a/examples/semantic_segmentation/eval_semantic_segmentation_multi.py
+++ b/examples/semantic_segmentation/eval_semantic_segmentation_multi.py
@@ -43,7 +43,7 @@ def main():
         return
 
     it = iterators.MultithreadIterator(
-        dataset, 1, repeat=False, shuffle=False)
+        dataset, comm.size, repeat=False, shuffle=False)
 
     in_values, out_values, rest_values = apply_to_iterator(
         model.predict, it, hook=ProgressHook(len(dataset)), comm=comm)

--- a/examples_tests/detection_tests/test_eval_coco_multi.sh
+++ b/examples_tests/detection_tests/test_eval_coco_multi.sh
@@ -1,0 +1,5 @@
+cd examples/detection
+sed -e 's/return_crowded=True)/return_crowded=True).slice[:20]/' -i eval_coco_multi.py
+
+$MPIEXEC $PYTHON eval_coco_multi.py --model faster_rcnn_fpn_resnet50 --batchsize 2
+$MPIEXEC $PYTHON eval_coco_multi.py --model faster_rcnn_fpn_resnet101 --batchsize 2

--- a/tests/utils_tests/iterator_tests/test_apply_to_iterator.py
+++ b/tests/utils_tests/iterator_tests/test_apply_to_iterator.py
@@ -96,15 +96,14 @@ class TestApplyToIterator(unittest.TestCase):
             self.hook = None
 
     def _check_apply_to_iterator(self, comm=None):
-        if comm is not None and not comm.rank == 0:
-            apply_to_iterator(
-                self.func, self.iterator, n_input=self.n_input,
-                hook=self.hook, comm=comm)
-            return
-
-        in_values, out_values, rest_values = apply_to_iterator(
+        values = apply_to_iterator(
             self.func, self.iterator, n_input=self.n_input,
             hook=self.hook, comm=comm)
+
+        if comm is not None and not comm.rank == 0:
+            return
+
+        in_values, out_values, rest_values = values
 
         self.assertEqual(len(in_values), self.n_input)
         for in_vals, in_vals_expect in \

--- a/tests/utils_tests/iterator_tests/test_apply_to_iterator.py
+++ b/tests/utils_tests/iterator_tests/test_apply_to_iterator.py
@@ -101,6 +101,7 @@ class TestApplyToIterator(unittest.TestCase):
             hook=self.hook, comm=comm)
 
         if comm is not None and not comm.rank == 0:
+            self.assertEqual(values, None)
             return
 
         in_values, out_values, rest_values = values

--- a/tests/utils_tests/iterator_tests/test_apply_to_iterator.py
+++ b/tests/utils_tests/iterator_tests/test_apply_to_iterator.py
@@ -5,8 +5,15 @@ import unittest
 import chainer
 from chainer.iterators import SerialIterator
 from chainer import testing
+from chainermn import create_communicator
 
 from chainercv.utils import apply_to_iterator
+
+try:
+    import mpi4py.MPI  # NOQA
+    _available = True
+except ImportError:
+    _available = False
 
 
 @testing.parameterize(*testing.product({
@@ -17,20 +24,20 @@ from chainercv.utils import apply_to_iterator
 }))
 class TestApplyToIterator(unittest.TestCase):
 
-    def test_apply_to_iterator(self):
+    def setUp(self):
         if self.multi_in_values:
-            n_input = 2
+            self.n_input = 2
         else:
-            n_input = 1
+            self.n_input = 1
 
         in_values_expect = []
-        for _ in range(n_input):
+        for _ in range(self.n_input):
             in_value = []
             for _ in range(5):
                 H, W = np.random.randint(8, 16, size=2)
                 in_value.append(np.random.randint(0, 256, size=(3, H, W)))
             in_values_expect.append(in_value)
-        in_values_expect = tuple(in_values_expect)
+        self.in_values_expect = tuple(in_values_expect)
 
         if self.multi_out_values:
             def func(*in_values):
@@ -40,72 +47,86 @@ class TestApplyToIterator(unittest.TestCase):
                     [np.random.uniform(size=10) for _ in range(n_sample)],
                     [np.random.uniform(size=10) for _ in range(n_sample)])
 
-            n_output = 3
+            self.n_output = 3
         else:
             def func(*in_values):
                 n_sample = len(in_values[0])
                 return [np.random.uniform(size=(48, 64))
                         for _ in range(n_sample)]
 
-            n_output = 1
+            self.n_output = 1
+        self.func = func
 
         if self.with_rest_values:
             strs = ['a', 'bc', 'def', 'ghij', 'klmno']
             nums = [0, 1, 2, 3, 4]
             arrays = [np.random.uniform(size=10) for _ in range(5)]
-            rest_values_expect = (strs, nums, arrays)
-            n_rest = 3
+            self.rest_values_expect = (strs, nums, arrays)
+            self.n_rest = 3
 
-            dataset = chainer.datasets.TupleDataset(
-                *(in_values_expect + rest_values_expect))
+            self.dataset = chainer.datasets.TupleDataset(
+                *(self.in_values_expect + self.rest_values_expect))
         else:
-            rest_values_expect = ()
-            n_rest = 0
+            self.rest_values_expect = ()
+            self.n_rest = 0
 
-            dataset = list(zip(*in_values_expect))
+            self. dataset = list(zip(*self.in_values_expect))
 
-        iterator = SerialIterator(dataset, 2, repeat=False, shuffle=False)
+        self.iterator = SerialIterator(
+            self.dataset, 2, repeat=False, shuffle=False)
 
         if self.with_hook:
             def hook(in_values, out_values, rest_values):
                 n_sample = len(in_values[0])
 
-                self.assertEqual(len(in_values), n_input)
+                self.assertEqual(len(in_values), self.n_input)
                 for in_vals in in_values:
                     self.assertEqual(len(in_vals), n_sample)
 
-                self.assertEqual(len(out_values), n_output)
+                self.assertEqual(len(out_values), self.n_output)
                 for out_vals in out_values:
                     self.assertEqual(len(out_vals), n_sample)
 
-                self.assertEqual(len(rest_values), n_rest)
+                self.assertEqual(len(rest_values), self.n_rest)
                 for rest_vals in rest_values:
                     self.assertEqual(len(rest_vals), n_sample)
+
+            self.hook = hook
         else:
-            hook = None
+            self.hook = None
 
+    def _check_apply_to_iterator(self, comm=None):
         in_values, out_values, rest_values = apply_to_iterator(
-            func, iterator, n_input=n_input, hook=hook)
+            self.func, self.iterator, n_input=self.n_input,
+            hook=self.hook, comm=comm)
 
-        self.assertEqual(len(in_values), n_input)
+        self.assertEqual(len(in_values), self.n_input)
         for in_vals, in_vals_expect in \
-                zip_longest(in_values, in_values_expect):
+                zip_longest(in_values, self.in_values_expect):
             for in_val, in_val_expect in zip_longest(in_vals, in_vals_expect):
                 np.testing.assert_equal(in_val, in_val_expect)
 
-        self.assertEqual(len(out_values), n_output)
+        self.assertEqual(len(out_values), self.n_output)
         for out_vals in out_values:
-            self.assertEqual(len(list(out_vals)), len(dataset))
+            self.assertEqual(len(list(out_vals)), len(self.dataset))
 
-        self.assertEqual(len(rest_values), n_rest)
+        self.assertEqual(len(rest_values), self.n_rest)
         for rest_vals, rest_vals_expect in \
-                zip_longest(rest_values, rest_values_expect):
+                zip_longest(rest_values, self.rest_values_expect):
             for rest_val, rest_val_expect in \
                     zip_longest(rest_vals, rest_vals_expect):
                 if isinstance(rest_val_expect, np.ndarray):
                     np.testing.assert_equal(rest_val, rest_val_expect)
                 else:
                     self.assertEqual(rest_val, rest_val_expect)
+
+    def test_apply_to_iterator(self):
+        self._check_apply_to_iterator()
+
+    @unittest.skipUnless(_available, 'mpi4py is not installed')
+    def test_apply_to_iterator_with_comm(self):
+        comm = create_communicator('naive')
+        self._check_apply_to_iterator(comm)
 
 
 class TestApplyToIteratorWithInfiniteIterator(unittest.TestCase):

--- a/tests/utils_tests/iterator_tests/test_apply_to_iterator.py
+++ b/tests/utils_tests/iterator_tests/test_apply_to_iterator.py
@@ -96,6 +96,12 @@ class TestApplyToIterator(unittest.TestCase):
             self.hook = None
 
     def _check_apply_to_iterator(self, comm=None):
+        if comm is not None and not comm.rank == 0:
+            apply_to_iterator(
+                self.func, self.iterator, n_input=self.n_input,
+                hook=self.hook, comm=comm)
+            return
+
         in_values, out_values, rest_values = apply_to_iterator(
             self.func, self.iterator, n_input=self.n_input,
             hook=self.hook, comm=comm)


### PR DESCRIPTION
```python
import time

from chainer.iterators import SerialIterator
import chainermn
from chainercv.utils import apply_to_iterator

comm = chainermn.create_communicator('naive')


def func(xs):
    time.sleep(1)
    ys = [x * x for x in xs]
    print('{}: {} -> {}'.format(comm.rank, xs, ys))
    return ys


if comm.rank == 0:
    dataset = [
        (3, 'one'), (4, 'one'), (5, 'nine'), (2, 'six'),
        (5, 'three'), (5, 'eight'), (9, 'seven'), (9, 'zero')]
    iter_ = SerialIterator(dataset, batch_size=5, repeat=False, shuffle=False)
    in_values, out_values, rest_values = apply_to_iterator(
        func, iter_, comm=comm)
    for in_, out, rest in zip(in_values[0], out_values[0], rest_values[0]):
        print(in_, out, rest)
else:
    apply_to_iterator(func, None, comm=comm)
```

with 3 workers
```
2: [5] -> [25]
1: [5, 2] -> [25, 4]
0: [3, 4] -> [9, 16]
3 9 one
4 16 one
5 25 nine
2 4 six
5 25 three
2: [9] -> [81]
1: [9] -> [81]
0: [5] -> [25]
5 25 eight
9 81 seven
9 81 zero
````
