### PR TITLE
fix resize when 0 length image is given

### DIFF
--- a/chainercv/transforms/image/resize.py
+++ b/chainercv/transforms/image/resize.py
@@ -61,6 +61,9 @@ def resize(img, size, interpolation=PIL.Image.BILINEAR):
         ~numpy.ndarray: A resize array in CHW format.
 
     """
+    if len(img) == 0:
+        return np.zeros((0,) + size, dtype=img.dtype)
+
     if chainer.config.cv_resize_backend == 'cv2':
         if _cv2_available:
             return _resize_cv2(img, size, interpolation)

--- a/chainercv/transforms/image/resize.py
+++ b/chainercv/transforms/image/resize.py
@@ -63,7 +63,7 @@ def resize(img, size, interpolation=PIL.Image.BILINEAR):
     """
     if len(img) == 0:
         assert len(size) == 2
-        return np.empty((-1,) + size, dtype=img.dtype)
+        return np.empty((0,) + size, dtype=img.dtype)
 
     if chainer.config.cv_resize_backend == 'cv2':
         if _cv2_available:

--- a/chainercv/transforms/image/resize.py
+++ b/chainercv/transforms/image/resize.py
@@ -62,6 +62,7 @@ def resize(img, size, interpolation=PIL.Image.BILINEAR):
 
     """
     if len(img) == 0:
+        assert len(size) == 2
         return np.zeros((0,) + size, dtype=img.dtype)
 
     if chainer.config.cv_resize_backend == 'cv2':

--- a/chainercv/transforms/image/resize.py
+++ b/chainercv/transforms/image/resize.py
@@ -63,7 +63,7 @@ def resize(img, size, interpolation=PIL.Image.BILINEAR):
     """
     if len(img) == 0:
         assert len(size) == 2
-        return np.zeros((0,) + size, dtype=img.dtype)
+        return np.empty((-1,) + size, dtype=img.dtype)
 
     if chainer.config.cv_resize_backend == 'cv2':
         if _cv2_available:

--- a/tests/transforms_tests/image_tests/test_resize.py
+++ b/tests/transforms_tests/image_tests/test_resize.py
@@ -27,5 +27,11 @@ class TestResize(unittest.TestCase):
         out = resize(img, size=(32, 64), interpolation=self.interpolation)
         self.assertEqual(out.shape, (1, 32, 64))
 
+    def test_zero_length_img(self):
+        img = np.random.uniform(size=(0, 24, 32))
+        chainer.config.cv_resize_backend = self.backend
+        out = resize(img, size=(32, 64), interpolation=self.interpolation)
+        self.assertEqual(out.shape, (0, 32, 64))
+
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR fixes an unintended behavior of `resize` when img of lenght 0 is given.
The example that demonstrates the behavior is below.
```python
import numpy as np
import PIL.Image

from chainercv.transforms import resize


x = np.zeros((0, 512, 400), dtype=np.float32)
out = resize(x, (400, 500), interpolation=PIL.Image.NEAREST)
print(out.shape)  # (512, 400, 500)
```