### PR TITLE
Set names of output Variables from PickableSequentialChain

### DIFF
--- a/chainercv/links/model/pickable_sequential_chain.py
+++ b/chainercv/links/model/pickable_sequential_chain.py
@@ -143,6 +143,7 @@ class PickableSequentialChain(chainer.Chain):
         h = x
         for name in self.layer_names[:last_index + 1]:
             h = self[name](h)
+            h.name = name
             if name in pick:
                 layers[name] = h
 

--- a/tests/links_tests/model_tests/test_pickable_sequential_chain.py
+++ b/tests/links_tests/model_tests/test_pickable_sequential_chain.py
@@ -60,6 +60,7 @@ class PickableSequentialChainTestBase(object):
         for out, layer_name in zip(outs, pick):
             self.assertIsInstance(out, chainer.Variable)
             self.assertIsInstance(out.array, self.link.xp.ndarray)
+            self.assertEqual(out.name, layer_name)
 
             out = to_cpu(out.array)
             np.testing.assert_equal(out, to_cpu(expects[layer_name].array))


### PR DESCRIPTION
Set names of output `Variable`s from `PickableSequentialChain`, so that they match with names in `pick` and `layer_names`.

This is for more readable computational graphs.