### PR TITLE
Fix docstring of DirectoryParsingLabelDataset

### DIFF
--- a/chainercv/datasets/directory_parsing_label_dataset.py
+++ b/chainercv/datasets/directory_parsing_label_dataset.py
@@ -93,7 +93,7 @@ class DirectoryParsingLabelDataset(GetterDataset):
 
         >>> from chainercv.datasets import DirectoryParsingLabelDataset
         >>> dataset = DirectoryParsingLabelDataset('root')
-        >>> dataset.paths
+        >>> dataset.img_paths
         ['root/class_0/img_0.png', 'root/class_0/img_1.png',
         'root_class_1/img_0.png']
         >>> dataset.labels


### PR DESCRIPTION
This is a small fix to the docstring of class `DirectoryParsingLabelDataset`. I think it does not have property `paths` and `img_paths` is appropriate here.