### PR TITLE
FPN - Add min/max size params for pre-processing.

### DIFF
--- a/chainercv/links/model/fpn/faster_rcnn.py
+++ b/chainercv/links/model/fpn/faster_rcnn.py
@@ -46,7 +46,7 @@ class FasterRCNN(chainer.Chain):
     _stride = 32
 
     def __init__(self, extractor, rpn, head,
-                 min_size, max_size):
+                 min_size=800, max_size=1333):
         super(FasterRCNN, self).__init__()
         with self.init_scope():
             self.extractor = extractor

--- a/chainercv/links/model/fpn/faster_rcnn.py
+++ b/chainercv/links/model/fpn/faster_rcnn.py
@@ -26,6 +26,9 @@ class FasterRCNN(chainer.Chain):
         head (Link): A link that has the same interface as
             :class:`~chainercv.links.model.fpn.Head`.
             Please refer to the documentation found there.
+        min_size (int): A preprocessing paramter for :meth:`prepare`. Please
+            refer to a docstring found for :meth:`prepare`.
+        max_size (int): A preprocessing paramter for :meth:`prepare`.
 
     Parameters:
         nms_thresh (float): The threshold value
@@ -40,16 +43,18 @@ class FasterRCNN(chainer.Chain):
 
     """
 
-    _min_size = 800
-    _max_size = 1333
     _stride = 32
 
-    def __init__(self, extractor, rpn, head):
+    def __init__(self, extractor, rpn, head,
+                 min_size, max_size):
         super(FasterRCNN, self).__init__()
         with self.init_scope():
             self.extractor = extractor
             self.rpn = rpn
             self.head = head
+
+        self._min_size = min_size
+        self._max_size = max_size
 
         self.use_preset('visualize')
 

--- a/chainercv/links/model/fpn/faster_rcnn.py
+++ b/chainercv/links/model/fpn/faster_rcnn.py
@@ -28,7 +28,9 @@ class FasterRCNN(chainer.Chain):
             Please refer to the documentation found there.
         min_size (int): A preprocessing paramter for :meth:`prepare`. Please
             refer to a docstring found for :meth:`prepare`.
-        max_size (int): A preprocessing paramter for :meth:`prepare`.
+        max_size (int): A preprocessing paramter for :meth:`prepare`. Note
+            that the result of :meth:`prepare` can exceed this size due to
+            alignment with stride.
 
     Parameters:
         nms_thresh (float): The threshold value

--- a/chainercv/links/model/fpn/faster_rcnn_fpn_resnet.py
+++ b/chainercv/links/model/fpn/faster_rcnn_fpn_resnet.py
@@ -60,8 +60,8 @@ class FasterRCNNFPNResNet50(FasterRCNNFPNResNet):
     Args:
         n_fg_class (int): The number of classes excluding the background.
         pretrained_model (string): The weight file to be loaded.
-           This can take :obj:`'coco'`, `filepath` or :obj:`None`.
-           The default value is :obj:`None`.
+            This can take :obj:`'coco'`, `filepath` or :obj:`None`.
+            The default value is :obj:`None`.
 
             * :obj:`'coco'`: Load weights trained on train split of \
                 MS COCO 2017. \

--- a/chainercv/links/model/fpn/faster_rcnn_fpn_resnet.py
+++ b/chainercv/links/model/fpn/faster_rcnn_fpn_resnet.py
@@ -19,7 +19,8 @@ class FasterRCNNFPNResNet(FasterRCNN):
     A subclass of this class should have :obj:`_base` and :obj:`_models`.
     """
 
-    def __init__(self, n_fg_class=None, pretrained_model=None):
+    def __init__(self, n_fg_class=None, pretrained_model=None,
+                 min_size=800, max_size=1333):
         param, path = utils.prepare_pretrained_model(
             {'n_fg_class': n_fg_class}, pretrained_model, self._models)
 
@@ -56,8 +57,8 @@ class FasterRCNNFPNResNet50(FasterRCNNFPNResNet):
        Feature Pyramid Networks for Object Detection. CVPR 2017
 
     Args:
-       n_fg_class (int): The number of classes excluding the background.
-       pretrained_model (string): The weight file to be loaded.
+        n_fg_class (int): The number of classes excluding the background.
+        pretrained_model (string): The weight file to be loaded.
            This can take :obj:`'coco'`, `filepath` or :obj:`None`.
            The default value is :obj:`None`.
 
@@ -74,6 +75,9 @@ class FasterRCNNFPNResNet50(FasterRCNNFPNResNet):
             * `filepath`: A path of npz file. In this case, :obj:`n_fg_class` \
                 must be specified properly.
             * :obj:`None`: Do not load weights.
+        min_size (int): A preprocessing paramter for :meth:`prepare`. Please
+            refer to a docstring found for :meth:`prepare`.
+        max_size (int): A preprocessing paramter for :meth:`prepare`.
 
     """
 
@@ -99,10 +103,10 @@ class FasterRCNNFPNResNet101(FasterRCNNFPNResNet):
        Feature Pyramid Networks for Object Detection. CVPR 2017
 
     Args:
-       n_fg_class (int): The number of classes excluding the background.
-       pretrained_model (string): The weight file to be loaded.
-           This can take :obj:`'coco'`, `filepath` or :obj:`None`.
-           The default value is :obj:`None`.
+        n_fg_class (int): The number of classes excluding the background.
+        pretrained_model (string): The weight file to be loaded.
+            This can take :obj:`'coco'`, `filepath` or :obj:`None`.
+            The default value is :obj:`None`.
 
             * :obj:`'coco'`: Load weights trained on train split of \
                 MS COCO 2017. \
@@ -117,6 +121,9 @@ class FasterRCNNFPNResNet101(FasterRCNNFPNResNet):
             * `filepath`: A path of npz file. In this case, :obj:`n_fg_class` \
                 must be specified properly.
             * :obj:`None`: Do not load weights.
+        min_size (int): A preprocessing paramter for :meth:`prepare`. Please
+            refer to a docstring found for :meth:`prepare`.
+        max_size (int): A preprocessing paramter for :meth:`prepare`.
 
     """
 

--- a/chainercv/links/model/fpn/faster_rcnn_fpn_resnet.py
+++ b/chainercv/links/model/fpn/faster_rcnn_fpn_resnet.py
@@ -36,6 +36,7 @@ class FasterRCNNFPNResNet(FasterRCNN):
             extractor=extractor,
             rpn=RPN(extractor.scales),
             head=Head(param['n_fg_class'] + 1, extractor.scales),
+            min_size=min_size, max_size=max_size
         )
 
         if path == 'imagenet':
@@ -75,8 +76,8 @@ class FasterRCNNFPNResNet50(FasterRCNNFPNResNet):
             * `filepath`: A path of npz file. In this case, :obj:`n_fg_class` \
                 must be specified properly.
             * :obj:`None`: Do not load weights.
-        min_size (int): A preprocessing paramter for :meth:`prepare`. Please
-            refer to a docstring found for :meth:`prepare`.
+        min_size (int): A preprocessing paramter for :meth:`prepare`. Please \
+            refer to :meth:`prepare`.
         max_size (int): A preprocessing paramter for :meth:`prepare`.
 
     """
@@ -121,8 +122,8 @@ class FasterRCNNFPNResNet101(FasterRCNNFPNResNet):
             * `filepath`: A path of npz file. In this case, :obj:`n_fg_class` \
                 must be specified properly.
             * :obj:`None`: Do not load weights.
-        min_size (int): A preprocessing paramter for :meth:`prepare`. Please
-            refer to a docstring found for :meth:`prepare`.
+        min_size (int): A preprocessing paramter for :meth:`prepare`. Please \
+            refer to :meth:`prepare`.
         max_size (int): A preprocessing paramter for :meth:`prepare`.
 
     """

--- a/tests/links_tests/model_tests/fpn_tests/test_faster_rcnn.py
+++ b/tests/links_tests/model_tests/fpn_tests/test_faster_rcnn.py
@@ -55,8 +55,8 @@ class DummyFasterRCNN(FasterRCNN):
         },
         {
             'in_sizes': [(200, 50), (400, 100)],
-            'min_size': 200, 'max_size': 400,
-            'expected_shape': (400, 100),
+            'min_size': 200, 'max_size': 320,
+            'expected_shape': (320, 96),
         },
     ],
 ))

--- a/tests/links_tests/model_tests/fpn_tests/test_faster_rcnn.py
+++ b/tests/links_tests/model_tests/fpn_tests/test_faster_rcnn.py
@@ -63,8 +63,9 @@ class DummyFasterRCNN(FasterRCNN):
 class TestFasterRCNN(unittest.TestCase):
 
     def setUp(self):
-        self.link = DummyFasterRCNN(n_fg_class=self.n_fg_class, 
-                        min_size=self.min_size, max_size=self.max_size)
+        self.link = DummyFasterRCNN(n_fg_class=self.n_fg_class,
+                                    min_size=self.min_size,
+                                    max_size=self.max_size)
 
     def test_use_preset(self):
         self.link.nms_thresh = 0
@@ -137,8 +138,9 @@ class TestFasterRCNN(unittest.TestCase):
         imgs = [_random_array(np, (3, s[0], s[1])) for s in self.in_sizes]
         out, scales = self.link.prepare(imgs)
         self.assertIsInstance(out, np.ndarray)
-        full_expected_shape = (len(self.in_sizes), 
-            3, self.expected_shape[0], self.expected_shape[1])
+        full_expected_shape = (len(self.in_sizes), 3,
+                               self.expected_shape[0],
+                               self.expected_shape[1])
         self.assertEqual(out.shape, full_expected_shape)
 
 


### PR DESCRIPTION
Allow for the `min_size`, `max_size` parameter to be set when creating an FPN network. 
It is following the Faster-RCNN template. 