### PR TITLE
Set allow_pickle=True

### DIFF
--- a/tests/evaluations_tests/test_eval_detection_voc.py
+++ b/tests/evaluations_tests/test_eval_detection_voc.py
@@ -219,9 +219,11 @@ class TestEvalDetectionVOCAP(unittest.TestCase):
         base_url = 'https://chainercv-models.preferred.jp/tests'
 
         cls.dataset = np.load(request.urlretrieve(os.path.join(
-            base_url, 'eval_detection_voc_dataset_2017_06_06.npz'))[0])
+            base_url, 'eval_detection_voc_dataset_2017_06_06.npz'))[0],
+            allow_pickle=True)
         cls.result = np.load(request.urlretrieve(os.path.join(
-            base_url, 'eval_detection_voc_result_2017_06_06.npz'))[0])
+            base_url, 'eval_detection_voc_result_2017_06_06.npz'))[0],
+            allow_pickle=True)
 
     def test_eval_detection_voc(self):
         pred_bboxes = self.result['bboxes']

--- a/tests/evaluations_tests/test_eval_instance_segmentation_voc.py
+++ b/tests/evaluations_tests/test_eval_instance_segmentation_voc.py
@@ -157,10 +157,12 @@ class TestEvalInstanceSegmentationVOCAP(unittest.TestCase):
         cls.dataset = np.load(request.urlretrieve(os.path.join(
             base_url,
             'eval_instance_segmentation_voc_dataset_2018_04_04.npz'))[0],
+            allow_pickle=True,
             encoding='latin1')
         cls.result = np.load(request.urlretrieve(os.path.join(
             base_url,
             'eval_instance_segmentation_voc_result_2018_04_04.npz'))[0],
+            allow_pickle=True,
             encoding='latin1')
 
     def test_eval_instance_segmentation_voc(self):


### PR DESCRIPTION
```
Unpickling while loading requires explicit opt-in

The functions np.load, and np.lib.format.read_array take an
allow_pickle keyword which now defaults to False in response to
CVE-2019-6446 <https://nvd.nist.gov/vuln/detail/CVE-2019-6446>_.
```
https://github.com/numpy/numpy/releases/tag/v1.16.3