### PR TITLE
use pycocotools released in pypi

### DIFF
--- a/.pfnci/docker/devel/Dockerfile
+++ b/.pfnci/docker/devel/Dockerfile
@@ -77,7 +77,7 @@ RUN pip2 install --no-cache-dir \
     matplotlib==2.1 \
     mock \
     mpi4py \
-    'git+https://github.com/cocodataset/coco.git#egg=pycocotools&subdirectory=PythonAPI' \
+    pycocotools \
     pytest \
     scipy \
     && pip3 install --no-cache-dir \
@@ -85,6 +85,6 @@ RUN pip2 install --no-cache-dir \
     matplotlib \
     mock \
     mpi4py \
-    'git+https://github.com/cocodataset/coco.git#egg=pycocotools&subdirectory=PythonAPI' \
+    pycocotools \
     pytest \
     scipy

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
       export LD_LIBRARY_PATH="$HOME/miniconda/envs/chainercv/lib:$LD_LIBRARY_PATH";
       conda env create -f environment.yml;
       source activate chainercv;
-      (cd ..; pip install cython==0.28 'git+https://github.com/cocodataset/coco.git#egg=pycocotools&subdirectory=PythonAPI')
+      (cd ..; pip install cython==0.28 pycocotools)
     else
       conda env create -f environment_minimum.yml;
       source activate chainercv_minimum;

--- a/chainercv/datasets/coco/coco_instance_segmentation_dataset.py
+++ b/chainercv/datasets/coco/coco_instance_segmentation_dataset.py
@@ -78,8 +78,7 @@ class COCOInstanceSegmentationDataset(COCOInstancesBaseDataset):
         if not _available:
             raise ValueError(
                 'Please install pycocotools \n'
-                'pip install -e \'git+https://github.com/cocodataset/coco.git'
-                '#egg=pycocotools&subdirectory=PythonAPI\'')
+                'pip install pycocotools')
         super(COCOInstanceSegmentationDataset, self).__init__(
             data_dir, split, year, use_crowded)
 

--- a/chainercv/evaluations/eval_detection_coco.py
+++ b/chainercv/evaluations/eval_detection_coco.py
@@ -140,8 +140,7 @@ def eval_detection_coco(pred_bboxes, pred_labels, pred_scores, gt_bboxes,
     if not _available:
         raise ValueError(
             'Please install pycocotools \n'
-            'pip install -e \'git+https://github.com/cocodataset/coco.git'
-            '#egg=pycocotools&subdirectory=PythonAPI\'')
+            'pip install pycocotools')
 
     gt_coco = pycocotools.coco.COCO()
     pred_coco = pycocotools.coco.COCO()

--- a/chainercv/evaluations/eval_instance_segmentation_coco.py
+++ b/chainercv/evaluations/eval_instance_segmentation_coco.py
@@ -140,8 +140,7 @@ def eval_instance_segmentation_coco(
     if not _available:
         raise ValueError(
             'Please install pycocotools \n'
-            'pip install -e \'git+https://github.com/cocodataset/coco.git'
-            '#egg=pycocotools&subdirectory=PythonAPI\'')
+            'pip install pycocotools')
 
     gt_coco = pycocotools.coco.COCO()
     pred_coco = pycocotools.coco.COCO()

--- a/chainercv/extensions/evaluator/detection_coco_evaluator.py
+++ b/chainercv/extensions/evaluator/detection_coco_evaluator.py
@@ -116,8 +116,7 @@ class DetectionCOCOEvaluator(chainer.training.extensions.Evaluator):
         if not _available:
             raise ValueError(
                 'Please install pycocotools \n'
-                'pip install -e \'git+https://github.com/cocodataset/coco.git'
-                '#egg=pycocotools&subdirectory=PythonAPI\'')
+                'pip install pycocotools')
         super(DetectionCOCOEvaluator, self).__init__(
             iterator, target)
         self.label_names = label_names

--- a/chainercv/extensions/evaluator/instance_segmentation_coco_evaluator.py
+++ b/chainercv/extensions/evaluator/instance_segmentation_coco_evaluator.py
@@ -116,8 +116,7 @@ class InstanceSegmentationCOCOEvaluator(chainer.training.extensions.Evaluator):
         if not _available:
             raise ValueError(
                 'Please install pycocotools \n'
-                'pip install -e \'git+https://github.com/cocodataset/coco.git'
-                '#egg=pycocotools&subdirectory=PythonAPI\'')
+                'pip install pycocotools')
         super(InstanceSegmentationCOCOEvaluator, self).__init__(
             iterator, target)
         self.label_names = label_names


### PR DESCRIPTION
I switch to use `pycocotools` via pypi.
now `pycocotools` is released via pypi.
https://pypi.org/project/pycocotools/