### PR TITLE
DetectionVisReport save tight figure

### DIFF
--- a/chainercv/extensions/vis_report/detection_vis_report.py
+++ b/chainercv/extensions/vis_report/detection_vis_report.py
@@ -137,7 +137,7 @@ class DetectionVisReport(chainer.training.extension.Extension):
                     img, pred_bbox, pred_label, pred_score,
                     label_names=self.label_names, ax=ax_pred)
 
-                plt.savefig(out_file)
+                plt.savefig(out_file, bbox_inches='tight')
                 plt.close()
 
                 idx += 1


### PR DESCRIPTION
Ask matplotlib to save a tight figure to limit the amount of unnecessary whitespace around the detection plots.