### PR TITLE
fix doc build

### DIFF
--- a/docs/rtd_conda.yml
+++ b/docs/rtd_conda.yml
@@ -1,0 +1,8 @@
+# Conda environment definition to build documentation on RTD
+
+name: chainercv-docs
+dependencies:
+  - python=3.5
+  - cmake
+  - numpy
+  - Cython

--- a/docs/rtd_conda.yml
+++ b/docs/rtd_conda.yml
@@ -2,7 +2,7 @@
 
 name: chainercv-docs
 dependencies:
-  - python=3.5
+  - python=3.6
   - cmake
   - numpy
   - Cython

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,5 +4,5 @@ base: docs/source
 conda:
   file: docs/rtd_conda.yml
 python:
-  version: 3.5
+  version: 3.6
   setup_py_install: true

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,8 @@
 name: chainercv
 type: sphinx
 base: docs/source
-requirements_file: docs/requirements.txt
+conda:
+  file: docs/rtd_conda.yml
 python:
+  version: 3.5
   setup_py_install: true


### PR DESCRIPTION
fix doc build
- we need to build `chainerx` because of these lines https://github.com/chainer/chainer/blob/54966403f2d4ceca91c041adc272b7372d773dd1/setup.py#L188-L190
- in order to build `chainerx`, we need `python=3.5` `cmake`
- I switch to use conda to build readthedoc environment
- build succeeded
https://readthedocs.org/projects/knorth55-chainercv/builds/9157251/