### PR TITLE
Better human readable representation for PickableSequentialChain

### DIFF
--- a/chainercv/links/model/pickable_sequential_chain.py
+++ b/chainercv/links/model/pickable_sequential_chain.py
@@ -1,4 +1,5 @@
 import copy
+import inspect
 
 import chainer
 
@@ -160,3 +161,24 @@ class PickableSequentialChain(chainer.Chain):
         copied._return_tuple = copy.copy(self._return_tuple)
 
         return copied
+
+    def __str__(self):
+        reps = []
+        for name in self.layer_names:
+            layer = self[name]
+            # Explore better representation by if-block.
+            if getattr(layer, '__name__', None) == '<lambda>':
+                rep = inspect.getsource(layer).strip().rstrip(',')
+            else:
+                rep = str(layer)
+            # Add indentation to each line.
+            rep = '({name}): {rep},'.format(name=name, rep=rep)
+            for line in rep.splitlines():
+                reps.append('  {line}\n'.format(line=line))
+        reps = ''.join(reps)
+        if reps:  # No newline with no layers.
+            reps = '\n' + reps
+
+        return '{cls}({layers})'.format(
+            cls=self.__class__.__name__, layers=reps,
+        )


### PR DESCRIPTION
Since https://github.com/chainer/chainer/pull/4853, print message of links became much more readable.

For chains, the order of child links is arbitrary when printed.
PickableSequentialChain has innate sequential nature, which should be reflected on the printed message.
This PR fixes this problem.

## Before this PR

```python

from chainercv.links import ResNet50
l = ResNet50()
print(l)
```
```
ResNet50(
  (conv1): Conv2DBNActiv(
    (bn): BatchNormalization(size=64, decay=0.9, eps=2e-05, dtype=float32, use_gamma=True, use_beta=True),
    (conv): Convolution2D(in_channels=None, out_channels=64, ksize=7, stride=(2, 2), pad=(3, 3), nobias=True, dilate=(1, 1), groups=1),
  ),
  (pool1): self.pool1 = lambda x: F.max_pooling_2d(x, ksize=3, stride=2),
  (res2): ResBlock(
...
```