### PR TITLE
Add type of args.lr in train_multi.py of PSPNet example

### DIFF
--- a/examples/pspnet/train_multi.py
+++ b/examples/pspnet/train_multi.py
@@ -170,7 +170,7 @@ def main():
                         choices=('ade20k', 'cityscapes'))
     parser.add_argument('--model',
                         choices=('pspnet_resnet101', 'pspnet_resnet50'))
-    parser.add_argument('--lr', default=1e-2)
+    parser.add_argument('--lr', default=1e-2, type=float)
     parser.add_argument('--batchsize', default=2, type=int)
     parser.add_argument('--out', default='result')
     parser.add_argument('--iteration', default=None, type=int)


### PR DESCRIPTION
The script set `1e-2` as `args.lr` in argparse but didn't set its type (`float`). If we change from command line like `--lr 5e-3`, it is interpreted as `str` and error happens. This fixed it.