### PR TITLE
fixed typo chainer to chair

### DIFF
--- a/chainercv/datasets/online_products/online_products_dataset.py
+++ b/chainercv/datasets/online_products/online_products_dataset.py
@@ -14,7 +14,7 @@ url = 'http://ftp.cs.stanford.edu/cs/cvgl/Stanford_Online_Products.zip'
 online_products_super_label_names = (
     'bicycle',
     'cabinet',
-    'chainer',
+    'chair',
     'coffe_maker',
     'fan',
     'kettle',


### PR DESCRIPTION
Wrong label name. 
It's "chair" not "chainer".
