### PR TITLE
Fix a typo in the label list of Stanford Online Products Dataset

### DIFF
--- a/chainercv/datasets/online_products/online_products_dataset.py
+++ b/chainercv/datasets/online_products/online_products_dataset.py
@@ -15,7 +15,7 @@ online_products_super_label_names = (
     'bicycle',
     'cabinet',
     'chair',
-    'coffe_maker',
+    'coffee_maker',
     'fan',
     'kettle',
     'lamp',


### PR DESCRIPTION
`coffe_maker` is a typo of `coffee_maker`