### PR TITLE
Honor the original data type in resize

### DIFF
--- a/chainercv/transforms/image/resize.py
+++ b/chainercv/transforms/image/resize.py
@@ -34,7 +34,7 @@ def _resize_pil(img, size, interpolation):
     H, W = size
     out = np.empty((C, H, W), dtype=img.dtype)
     for ch, out_ch in zip(img, out):
-        ch = PIL.Image.fromarray(ch, mode='F')
+        ch = PIL.Image.fromarray(ch)
         out_ch[:] = ch.resize((W, H), resample=interpolation)
     return out
 

--- a/tests/transforms_tests/image_tests/test_resize.py
+++ b/tests/transforms_tests/image_tests/test_resize.py
@@ -45,6 +45,16 @@ class TestResize(unittest.TestCase):
             out = resize(img, size=(32, 64), interpolation=self.interpolation)
         self.assertEqual(out.shape, (0, 32, 64))
 
+    def test_resize_labels(self):
+        if self.backend == 'cv2' and not _cv2_available:
+            return
+        dtype = np.int32
+        labels = np.arange(2, dtype=dtype).reshape(2, 1)
+        with chainer.using_config('cv_resize_backend', self.backend):
+            out = resize(labels[None], size=(2, 4), interpolation=self.interpolation)
+        expected = np.vstack((np.zeros(4), np.ones(4))).astype(dtype).reshape(1, 2, 4)
+        self.assertTrue(np.array_equal(out, expected))
+
 
 @unittest.skipUnless(not _cv2_available, 'cv2 is installed')
 class TestResizeRaiseErrorWithCv2(unittest.TestCase):

--- a/tests/transforms_tests/image_tests/test_resize.py
+++ b/tests/transforms_tests/image_tests/test_resize.py
@@ -49,10 +49,12 @@ class TestResize(unittest.TestCase):
         if self.backend == 'cv2' and not _cv2_available:
             return
         dtype = np.int32
-        labels = np.arange(2, dtype=dtype).reshape(2, 1)
+        labels = np.arange(2, dtype=dtype).reshape((2, 1))
         with chainer.using_config('cv_resize_backend', self.backend):
-            out = resize(labels[None], size=(2, 4), interpolation=self.interpolation)
-        expected = np.vstack((np.zeros(4), np.ones(4))).astype(dtype).reshape(1, 2, 4)
+            out = resize(
+                labels[None], size=(2, 4), interpolation=self.interpolation)
+        expected = np.vstack(
+            (np.zeros(4), np.ones(4))).astype(dtype).reshape((1, 2, 4))
         self.assertTrue(np.array_equal(out, expected))
 
 


### PR DESCRIPTION
Hello I think this is a cool project.

I came across what looked like a bug when I was running the example for PSP:

https://github.com/chainer/chainercv/blob/b4647d3960d3e1e66834036c9f386a964813d5a6/examples/pspnet/train_multi.py#L96

specifically, `numpy.unique(label)` here would only output `[-1 ,0]`, where more classes should be preserved after the resize.

The offending test case is added in this PR as `test_resize_labels`, in which an array of `int` type is passed to the resize method.

The fix is to use the [default](https://pillow.readthedocs.io/en/4.2.x/reference/Image.html#PIL.Image.fromarray) `mode` specified by PIL which will determine the mode automatically from the given data.

You may also decide to accept only `float` types for the resize method. In that case the PSP example needs a bug fix like `transforms.resize(labels.astype(np.float32)`, and I would assert against violating types in the `resize` method.