### PR TITLE
Check for invalid cv_resize_backend options.

### DIFF
--- a/chainercv/transforms/image/resize.py
+++ b/chainercv/transforms/image/resize.py
@@ -78,3 +78,6 @@ def resize(img, size, interpolation=PIL.Image.BILINEAR):
         return _resize_cv2(img, size, interpolation)
     elif chainer.config.cv_resize_backend == 'PIL':
         return _resize_pil(img, size, interpolation)
+    else:
+        raise ValueError('chainer.config.cv_resize_backend must be one of:'
+                         '[\'cv2\', \'PIL\']')

--- a/tests/transforms_tests/image_tests/test_resize.py
+++ b/tests/transforms_tests/image_tests/test_resize.py
@@ -46,6 +46,15 @@ class TestResize(unittest.TestCase):
         self.assertEqual(out.shape, (0, 32, 64))
 
 
+class TestResizeWithInvalidConfig(unittest.TestCase):
+
+    def test_invalid_backend(self):
+        img = np.random.uniform(size=(3, 24, 32))
+        with chainer.using_config('cv_resize_backend', 'PII'):
+            with self.assertRaises(ValueError):
+                resize(img, size=(32, 64))
+
+
 @unittest.skipUnless(not _cv2_available, 'cv2 is installed')
 class TestResizeRaiseErrorWithCv2(unittest.TestCase):
 


### PR DESCRIPTION
Currently a typo will result in the method silently returning `None`, which I think is counter intuitive and forces users to debug.