### PR TITLE
Add dice score calculation for SemanticSegmentationEvaluator

### DIFF
--- a/chainercv/evaluations/__init__.py
+++ b/chainercv/evaluations/__init__.py
@@ -6,5 +6,6 @@ from chainercv.evaluations.eval_instance_segmentation_coco import eval_instance_
 from chainercv.evaluations.eval_instance_segmentation_voc import calc_instance_segmentation_voc_prec_rec  # NOQA
 from chainercv.evaluations.eval_instance_segmentation_voc import eval_instance_segmentation_voc  # NOQA
 from chainercv.evaluations.eval_semantic_segmentation import calc_semantic_segmentation_confusion  # NOQA
+from chainercv.evaluations.eval_semantic_segmentation import calc_semantic_segmentation_dice  # NOQA
 from chainercv.evaluations.eval_semantic_segmentation import calc_semantic_segmentation_iou  # NOQA
 from chainercv.evaluations.eval_semantic_segmentation import eval_semantic_segmentation  # NOQA

--- a/chainercv/evaluations/eval_semantic_segmentation.py
+++ b/chainercv/evaluations/eval_semantic_segmentation.py
@@ -1,5 +1,7 @@
 from __future__ import division
 
+import collections
+
 import numpy as np
 import six
 
@@ -60,6 +62,26 @@ def calc_semantic_segmentation_confusion(pred_labels, gt_labels):
         if next(iter_, None) is not None:
             raise ValueError('Length of input iterables need to be same')
     return confusion
+
+
+def calc_semantic_segmentation_dice(pred_labels, gt_labels):
+    klasses = np.unique(np.concatenate((pred_labels, gt_labels)))
+    scores = collections.defaultdict(int)
+    for pred_label, gt_label in six.moves.zip(pred_labels, gt_labels):
+        for klass in klasses:
+            p = pred_label == klass
+            g = gt_label == klass
+            numerator = 2 * np.sum(np.logical_and(p, g))
+            denominator = np.sum(p) + np.sum(g)
+            if denominator == 0:
+                scores[klass] += 1
+            else:
+                scores[klass] += numerator / denominator
+
+    n_labels = len(pred_labels)
+    for klass in scores:
+        scores[klass] /= n_labels
+    return scores
 
 
 def calc_semantic_segmentation_iou(confusion):

--- a/tests/evaluations_tests/test_eval_semantic_segmentation.py
+++ b/tests/evaluations_tests/test_eval_semantic_segmentation.py
@@ -5,6 +5,7 @@ import unittest
 import numpy as np
 
 from chainercv.evaluations import calc_semantic_segmentation_confusion
+from chainercv.evaluations import calc_semantic_segmentation_dice
 from chainercv.evaluations import calc_semantic_segmentation_iou
 from chainercv.evaluations import eval_semantic_segmentation
 from chainercv.utils import testing
@@ -67,6 +68,35 @@ class TestCalcSemanticSegmentationConfusion(unittest.TestCase):
 
         size = (np.max((pred_labels + 1, gt_labels + 1)))
         self.assertEqual(confusion.shape, (size, size))
+
+
+class TestCalcSemanticSegmentationDice(unittest.TestCase):
+
+    n_class = 2
+
+    def test_calc_semantic_segmentation_dice(self):
+        pred_labels = [
+            np.array([
+                [0, 0, 1],
+                [1, 0, 1],
+            ]), np.array([
+                [0, 0, 0],
+                [0, 0, 0],
+            ])]
+
+        gt_labels = [
+            np.array([
+                [0, 0, 1],
+                [1, 0, 1],
+            ]), np.array([
+                [0, -1, 0],
+                [-1, 0, -1],
+            ])]
+
+        dice = calc_semantic_segmentation_dice(pred_labels, gt_labels)
+        np.testing.assert_equal(dice[-1], (1.0 + 0.0) / 2)
+        np.testing.assert_equal(dice[0], (1.0 + 2.0 * 3 / 9) / 2)
+        np.testing.assert_equal(dice[1], (1.0 + 1.0) / 2)
 
 
 class TestCalcSemanticSegmentationIou(unittest.TestCase):


### PR DESCRIPTION
Hello ChainerCV team.

I wanted a [Dice score](https://en.wikipedia.org/wiki/Sørensen–Dice_coefficient) evaluator for semantic segmentation so I started by adding a method for it.
If you think this is a good idea I'll continue to implement a `chainer.training.extensions.Evaluator`, either as an option for the `SemanticSegmentationEvaluator` or by changing its name that implies IOU is used and also adding a Dice version.