### PR TITLE
Match the remote version to the local in CI

### DIFF
--- a/.pfnci/common.sh
+++ b/.pfnci/common.sh
@@ -12,8 +12,10 @@ gcloud auth configure-docker
 TEMP=$(mktemp -d)
 mount -t tmpfs tmpfs ${TEMP}/ -o size=100%
 
-git merge-base --is-ancestor HEAD v6 && LOCAL_VERSION=stable
-git merge-base --is-ancestor HEAD master && LOCAL_VERSION=master
+function get_local_version() {
+    git merge-base --is-ancestor HEAD v6 && LOCAL_VERSION=stable 
+    git merge-base --is-ancestor HEAD master && LOCAL_VERSION=master
+}
 
 REPOSITORY=${REPOSITORY:-chainercv}
 case ${REPOSITORY} in
@@ -22,12 +24,14 @@ case ${REPOSITORY} in
         cp -a . ${TEMP}/chainercv
         ;;
     chainer)
+        get_local_version
         CHAINER=local
         CUPY=${LOCAL_VERSION}
         cp -a . ${TEMP}/chainer
         mv ${TEMP}/chainer/chainercv/ ${TEMP}/
         ;;
     cupy)
+        get_local_version
         CHAINER=${LOCAL_VERSION}
         CUPY=local
         cp -a . ${TEMP}/cupy

--- a/.pfnci/common.sh
+++ b/.pfnci/common.sh
@@ -13,8 +13,8 @@ TEMP=$(mktemp -d)
 mount -t tmpfs tmpfs ${TEMP}/ -o size=100%
 
 get_local_version() {
-    git merge-base --is-ancestor HEAD v6 && LOCAL_VERSION=stable 
-    git merge-base --is-ancestor HEAD master && LOCAL_VERSION=master
+    git merge-base --is-ancestor v6 HEAD && LOCAL_VERSION=stable 
+    git merge-base --is-ancestor master HEAD && LOCAL_VERSION=master
 }
 
 REPOSITORY=${REPOSITORY:-chainercv}

--- a/.pfnci/common.sh
+++ b/.pfnci/common.sh
@@ -1,8 +1,8 @@
 #! /usr/bin/env sh
 set -eux
 
-STABLE=6.3.0
-LATEST=7.0.0b3
+STABLE=6.4.0
+LATEST=7.0.0b4
 
 systemctl stop docker.service
 mount -t tmpfs tmpfs /var/lib/docker/ -o size=100%

--- a/.pfnci/common.sh
+++ b/.pfnci/common.sh
@@ -12,6 +12,9 @@ gcloud auth configure-docker
 TEMP=$(mktemp -d)
 mount -t tmpfs tmpfs ${TEMP}/ -o size=100%
 
+git merge-base --is-ancestor HEAD v6 && LOCAL_VERSION=stable
+git merge-base --is-ancestor HEAD master && LOCAL_VERSION=master
+
 REPOSITORY=${REPOSITORY:-chainercv}
 case ${REPOSITORY} in
     chainercv)
@@ -20,12 +23,12 @@ case ${REPOSITORY} in
         ;;
     chainer)
         CHAINER=local
-        CUPY=master
+        CUPY=${LOCAL_VERSION}
         cp -a . ${TEMP}/chainer
         mv ${TEMP}/chainer/chainercv/ ${TEMP}/
         ;;
     cupy)
-        CHAINER=master
+        CHAINER=${LOCAL_VERSION}
         CUPY=local
         cp -a . ${TEMP}/cupy
         mv ${TEMP}/cupy/chainercv/ ${TEMP}/

--- a/.pfnci/common.sh
+++ b/.pfnci/common.sh
@@ -12,7 +12,7 @@ gcloud auth configure-docker
 TEMP=$(mktemp -d)
 mount -t tmpfs tmpfs ${TEMP}/ -o size=100%
 
-function get_local_version() {
+get_local_version() {
     git merge-base --is-ancestor HEAD v6 && LOCAL_VERSION=stable 
     git merge-base --is-ancestor HEAD master && LOCAL_VERSION=master
 }


### PR DESCRIPTION
In the current CI, when testing a pull request to Chainer (CuPy) stable branch, the script installs the master version of CuPy (Chainer). This PR fixes the script to use the stable version of CuPy (Chainer) in such a case. It will hopefully resolve some troubles after dropping Python2 in master branches.